### PR TITLE
Sortable signatures

### DIFF
--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/SystemSignaturesContent/SystemSignaturesContent.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/SystemSignaturesContent/SystemSignaturesContent.tsx
@@ -178,7 +178,6 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
             resizableColumns
             rowHover
             selectAll
-            showHeaders={true}
             sortField="eve_id"
             onRowMouseEnter={handleEnterRow}
             onRowMouseLeave={handleLeaveRow}

--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/SystemSignaturesContent/SystemSignaturesContent.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/SystemSignaturesContent/SystemSignaturesContent.tsx
@@ -178,7 +178,8 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
             resizableColumns
             rowHover
             selectAll
-            showHeaders={false}
+            showHeaders={true}
+            sortField="eve_id"
             onRowMouseEnter={handleEnterRow}
             onRowMouseLeave={handleLeaveRow}
             rowClassName={row => {
@@ -199,6 +200,7 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
               field="group"
               body={renderIcon}
               style={{ maxWidth: 26, minWidth: 26, width: 26 }}
+              headerStyle={{ fontSize: "14px", padding: "0.25rem" }}
             ></Column>
 
             <Column
@@ -206,12 +208,16 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
               header="Id"
               bodyClassName="text-ellipsis overflow-hidden whitespace-nowrap"
               style={{ maxWidth: 72, minWidth: 72, width: 72 }}
+              headerStyle={{ fontSize: "14px", padding: "0.25rem" }}
+              sortable
             ></Column>
             <Column
               field="group"
               header="Group"
               bodyClassName="text-ellipsis overflow-hidden whitespace-nowrap"
               hidden={compact}
+              headerStyle={{ fontSize: "14px", padding: "0.25rem" }}
+              sortable
             ></Column>
             <Column
               field="name"
@@ -220,6 +226,8 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
               body={renderName}
               style={{ maxWidth: nameColumnWidth }}
               hidden={compact || medium}
+              headerStyle={{ fontSize: "14px", padding: "0.25rem" }}
+              sortable
             ></Column>
             <Column
               field="updated_at"
@@ -227,6 +235,8 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
               dataType="date"
               bodyClassName="w-[80px] text-ellipsis overflow-hidden whitespace-nowrap"
               body={renderTimeLeft}
+              headerStyle={{ fontSize: "14px", padding: "0.25rem" }}
+              sortable
             ></Column>
           </DataTable>
         </>


### PR DESCRIPTION
Re: https://github.com/wanderer-industries/wanderer/issues/15

Changes:
* Show header
* Marked columns as sortable and set custom style to reduce header size (sadly setting DataTable's size doesn't also control the header)

Oddities:
* Reversing default sort doesn't do anything until sorted by another column first. This may be a bug in PrimeReact.