### PR TITLE
Persist the signature sort between sessions and header improvements

### DIFF
--- a/assets/js/hooks/Mapper/common-styles/fixes.scss
+++ b/assets/js/hooks/Mapper/common-styles/fixes.scss
@@ -20,13 +20,12 @@
   position: absolute;
 }
 
-.p-menuitem,
-.p-menuitem-content {
+.p-menuitem, .p-menuitem-content {
   height: 36px;
   flex-grow: 1;
 }
 
-.p-menuitem>.p-menuitem-content>a {
+.p-menuitem > .p-menuitem-content>a {
   width: 100%;
   height: 100%;
 

--- a/assets/js/hooks/Mapper/common-styles/fixes.scss
+++ b/assets/js/hooks/Mapper/common-styles/fixes.scss
@@ -20,12 +20,13 @@
   position: absolute;
 }
 
-.p-menuitem, .p-menuitem-content {
+.p-menuitem,
+.p-menuitem-content {
   height: 36px;
   flex-grow: 1;
 }
 
-.p-menuitem > .p-menuitem-content > a {
+.p-menuitem>.p-menuitem-content>a {
   width: 100%;
   height: 100%;
 
@@ -67,3 +68,8 @@
   }
 }
 
+.p-sortable-column {
+  font-size: 12px;
+  font-weight: bold;
+  padding: 0.25rem 0.5rem;
+}

--- a/assets/js/hooks/Mapper/common-styles/fixes.scss
+++ b/assets/js/hooks/Mapper/common-styles/fixes.scss
@@ -25,7 +25,7 @@
   flex-grow: 1;
 }
 
-.p-menuitem > .p-menuitem-content>a {
+.p-menuitem > .p-menuitem-content > a {
   width: 100%;
   height: 100%;
 

--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/SystemSignaturesContent/SystemSignaturesContent.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/SystemSignaturesContent/SystemSignaturesContent.tsx
@@ -216,7 +216,6 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
               field="group"
               body={renderIcon}
               style={{ maxWidth: 26, minWidth: 26, width: 26 }}
-              headerStyle={{ fontSize: "14px", padding: "0.25rem" }}
             ></Column>
 
             <Column
@@ -224,7 +223,6 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
               header="Id"
               bodyClassName="text-ellipsis overflow-hidden whitespace-nowrap"
               style={{ maxWidth: 72, minWidth: 72, width: 72 }}
-              headerStyle={{ fontSize: "14px", padding: "0.25rem" }}
               sortable
             ></Column>
             <Column
@@ -232,7 +230,6 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
               header="Group"
               bodyClassName="text-ellipsis overflow-hidden whitespace-nowrap"
               hidden={compact}
-              headerStyle={{ fontSize: "14px", padding: "0.25rem" }}
               sortable
             ></Column>
             <Column
@@ -242,7 +239,6 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
               body={renderName}
               style={{ maxWidth: nameColumnWidth }}
               hidden={compact || medium}
-              headerStyle={{ fontSize: "14px", padding: "0.25rem" }}
               sortable
             ></Column>
             <Column
@@ -251,7 +247,6 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
               dataType="date"
               bodyClassName="w-[80px] text-ellipsis overflow-hidden whitespace-nowrap"
               body={renderTimeLeft}
-              headerStyle={{ fontSize: "14px", padding: "0.25rem" }}
               sortable
             ></Column>
           </DataTable>

--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/SystemSignaturesContent/SystemSignaturesContent.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/SystemSignaturesContent/SystemSignaturesContent.tsx
@@ -4,7 +4,7 @@ import { parseSignatures } from '@/hooks/Mapper/helpers';
 import { OutCommand } from '@/hooks/Mapper/types/mapHandlers.ts';
 import { WdTooltip, WdTooltipHandlers } from '@/hooks/Mapper/components/ui-kit';
 
-import { DataTable, DataTableRowMouseEvent } from 'primereact/datatable';
+import { DataTable, DataTableRowMouseEvent, SortOrder } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useRefState from 'react-usestateref';
@@ -25,6 +25,17 @@ import {
   renderName,
   renderTimeLeft,
 } from '@/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/renders';
+import useLocalStorageState from 'use-local-storage-state';
+
+type SystemSignaturesSortSettings = {
+  sortField: string;
+  sortOrder: SortOrder;
+}
+
+const SORT_DEFAULT_VALUES: SystemSignaturesSortSettings = {
+  sortField: 'eve_id',
+  sortOrder: 1
+};
 
 interface SystemSignaturesContentProps {
   systemId: string;
@@ -38,6 +49,10 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
   const [nameColumnWidth, setNameColumnWidth] = useState('auto');
 
   const [hoveredSig, setHoveredSig] = useState<SystemSignature | null>(null);
+
+  const [sortSettings, setSortSettings] = useLocalStorageState<SystemSignaturesSortSettings>('window:signatures:sort', {
+    defaultValue: SORT_DEFAULT_VALUES,
+  });
 
   const tableRef = useRef<HTMLDivElement>(null);
   const compact = useMaxWidth(tableRef, 260);
@@ -178,7 +193,9 @@ export const SystemSignaturesContent = ({ systemId, settings }: SystemSignatures
             resizableColumns
             rowHover
             selectAll
-            sortField="eve_id"
+            sortField={sortSettings.sortField}
+            sortOrder={sortSettings.sortOrder}
+            onSort={(event) => setSortSettings(() => ({ sortField: event.sortField, sortOrder: event.sortOrder }))}
             onRowMouseEnter={handleEnterRow}
             onRowMouseLeave={handleLeaveRow}
             rowClassName={row => {


### PR DESCRIPTION
* Stores signature field and direction in local storage
* Sets initial sort using value in local storage (or default)
* Setting the sort order fixed the issue with reversing default sort not working until selecting another column
* Fixed header alignment
* Improved the header display a little
* Moved the header CSS to fixes.scss.