### PR TITLE
 feat(map):  Enables left click select and right click pan and drag

### DIFF
--- a/assets/js/hooks/Mapper/components/map/Map.tsx
+++ b/assets/js/hooks/Mapper/components/map/Map.tsx
@@ -100,6 +100,7 @@ interface MapCompProps {
   isShowBackgroundPattern?: boolean;
   isSoftBackground?: boolean;
   theme?: string;
+  isRightPanDrag?: boolean;
 }
 
 const MapComp = ({
@@ -117,6 +118,7 @@ const MapComp = ({
   isShowBackgroundPattern,
   isSoftBackground,
   theme,
+  isRightPanDrag,
   onAddSystem,
 }: MapCompProps) => {
   const { getNode, getNodes } = useReactFlow();
@@ -282,6 +284,8 @@ const MapComp = ({
           maxZoom={1.5}
           elevateNodesOnSelect
           deleteKeyCode={['Delete']}
+          selectionOnDrag={isRightPanDrag}
+          panOnDrag={isRightPanDrag ? [2] : [0, 1, 2]}
           // TODO need create clear example with problem with that flag
           //  if system is not visible edge not drawing (and any render in Custom node is not happening)
           // onlyRenderVisibleElements

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/MapSettings.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/MapSettings.tsx
@@ -112,6 +112,10 @@ const UI_CHECKBOXES_PROPS: SettingsListItem[] = [
     label: 'Enable soft background',
     type: 'checkbox',
   },
+  { prop: InterfaceStoredSettingsProps.isRightPanDrag,
+    label: 'Enable left click select / right click pan',
+    type: 'checkbox',
+  },
 ];
 
 const THEME_OPTIONS = [

--- a/assets/js/hooks/Mapper/components/mapWrapper/MapWrapper.tsx
+++ b/assets/js/hooks/Mapper/components/mapWrapper/MapWrapper.tsx
@@ -41,6 +41,7 @@ export const MapWrapper = () => {
       isShowBackgroundPattern,
       isSoftBackground,
       theme,
+      isRightPanDrag,
     },
   } = useMapRootState();
   const { deleteSystems } = useDeleteSystems();
@@ -168,6 +169,7 @@ export const MapWrapper = () => {
         isShowBackgroundPattern={isShowBackgroundPattern}
         isSoftBackground={isSoftBackground}
         theme={theme}
+        isRightPanDrag={isRightPanDrag}
         onAddSystem={onAddSystem}
       />
 

--- a/assets/js/hooks/Mapper/mapRootProvider/MapRootProvider.tsx
+++ b/assets/js/hooks/Mapper/mapRootProvider/MapRootProvider.tsx
@@ -38,6 +38,7 @@ export enum InterfaceStoredSettingsProps {
   isShowBackgroundPattern = 'isShowBackgroundPattern',
   isSoftBackground = 'isSoftBackground',
   theme = 'theme',
+  isRightPanDrag = 'isRightPanDrag',
 }
 
 export type InterfaceStoredSettings = {
@@ -49,6 +50,7 @@ export type InterfaceStoredSettings = {
   isShowBackgroundPattern: boolean;
   isSoftBackground: boolean;
   theme: string;
+  isRightPanDrag: boolean;
 };
 
 export const STORED_INTERFACE_DEFAULT_VALUES: InterfaceStoredSettings = {
@@ -60,7 +62,8 @@ export const STORED_INTERFACE_DEFAULT_VALUES: InterfaceStoredSettings = {
   isShowBackgroundPattern: true,
   isSoftBackground: false,
   theme: 'default',
-}
+  isRightPanDrag: false,
+};
 
 export interface MapRootContextProps {
   update: ContextStoreDataUpdate<MapRootData>;


### PR DESCRIPTION
Adds user interface setting to toggle using the left mouse drag for selection and right click drag for pan.  Also adjusts css to have the selection box disappear after drag stop as nodes remain selected with highlighted boundary boxes.

![PanAndDrag](https://github.com/user-attachments/assets/21ca25af-b5f2-4643-8354-b82f567c8af8)
![GifDemo](https://github.com/user-attachments/assets/b268e484-ee96-47e7-b55d-ec49ecfd7183)


