### PR TITLE
fix: restored kills lightning bolt functionality

### DIFF
--- a/lib/wanderer_app/map/map_zkb_data_fetcher.ex
+++ b/lib/wanderer_app/map/map_zkb_data_fetcher.ex
@@ -160,25 +160,16 @@ defmodule WandererApp.Map.ZkbDataFetcher do
   defp maybe_broadcast_map_kills(new_kills_map, map_id) do
     {:ok, old_kills_map} = WandererApp.Cache.lookup("map_#{map_id}:zkb_kills", %{})
 
-    updated_kills_system_ids =
-      old_kills_map
-      |> Map.keys()
-      |> Enum.filter(fn system_id ->
+    # Use the union of keys from both the new and old maps
+    all_system_ids = Map.keys(Map.merge(new_kills_map, old_kills_map))
+
+    changed_system_ids =
+      Enum.filter(all_system_ids, fn system_id ->
         new_kills_count = Map.get(new_kills_map, system_id, 0)
         old_kills_count = Map.get(old_kills_map, system_id, 0)
-        new_kills_count != old_kills_count and new_kills_count > 0
+        new_kills_count != old_kills_count and
+          (new_kills_count > 0 or (old_kills_count > 0 and new_kills_count == 0))
       end)
-
-    removed_kills_system_ids =
-      old_kills_map
-      |> Map.keys()
-      |> Enum.filter(fn system_id ->
-        old_kills_count = Map.get(old_kills_map, system_id, 0)
-        new_kills_count = Map.get(new_kills_map, system_id, 0)
-        old_kills_count > 0 and new_kills_count == 0
-      end)
-
-    changed_system_ids = updated_kills_system_ids ++ removed_kills_system_ids
 
     if changed_system_ids == [] do
       :ok


### PR DESCRIPTION
### Summary of changes

#### 1. Original Behavior (before zkill widget PR)
- **Diff Computation:**  
  - The code computed changes in two parts:  
    - **Updated Kills:** Checked the new kills map for systems with increased (and positive) kill counts compared to the old kills map.  
    - **Removed Kills:** Examined the old kills map for systems where the kill count dropped to zero.
- **Broadcasting:**  
  - The two sets of system IDs were concatenated. If any changes were detected, the cache was updated and a `:kills_updated` event was broadcast with the changed systems.
- **Outcome:**  
  - This approach correctly detected changes for systems present in both maps, but could provide incorrect or incomplete information when a system was present in only one of the maps (either newly added or removed).

#### 2. Broken Behavior with zkill widget PR
- **Issue:**  
  - The modified code iterated **only over the keys from the old kills map** when determining changes.
- **Implication:**  
  - **New systems** (those present only in the new kills map) were missed because their keys were never considered.
- **Result:**  
  - The UI did not receive updates for new systems or for systems that weren’t in the old cache, leading to incomplete `:kills_updated` events.

#### 3. Fixed Behavior with the Updated Change
- **Improved Diff Computation:**  
  - The revised code computes the union of keys from both the new and old kills maps (using `Map.merge/2` and `Map.keys/1`), ensuring that all systems are considered.
- **Accurate Change Detection:**  
  - It then filters this complete set of keys to detect any differences in kill counts.
- **Result:**  
  - The broadcast now includes all relevant changes, ensuring the UI is properly updated whether a system is new, has updated kills, or has been removed.
