### PR TITLE
Add back signature expiration

### DIFF
--- a/lib/wanderer_app_web/live/maps/event_handlers/map_systems_event_handler.ex
+++ b/lib/wanderer_app_web/live/maps/event_handlers/map_systems_event_handler.ex
@@ -58,6 +58,17 @@ defmodule WandererAppWeb.MapSystemsEventHandler do
       socket
     else
       # Check if we already selected this exact system for this char:
+      case WandererApp.MapSystemRepo.get_by_map_and_solar_system_id(map_id, solar_system_id) do
+        {:ok, system} ->
+          WandererApp.Cache.put(
+            "map_#{map_id}:system_#{system.id}:last_activity",
+            DateTime.utc_now(),
+            ttl: @system_inactive_timeout
+          )
+        _ ->
+          :ok
+      end
+
       last_selected =
         WandererApp.Cache.lookup!(
           "char:#{character_id}:map:#{map_id}:last_selected_system_id",

--- a/lib/wanderer_app_web/live/maps/event_handlers/map_systems_event_handler.ex
+++ b/lib/wanderer_app_web/live/maps/event_handlers/map_systems_event_handler.ex
@@ -57,7 +57,6 @@ defmodule WandererAppWeb.MapSystemsEventHandler do
     if not must_select? do
       socket
     else
-      # Check if we already selected this exact system for this char:
       case WandererApp.MapSystemRepo.get_by_map_and_solar_system_id(map_id, solar_system_id) do
         {:ok, system} ->
           WandererApp.Cache.put(
@@ -68,7 +67,7 @@ defmodule WandererAppWeb.MapSystemsEventHandler do
         _ ->
           :ok
       end
-
+      # Check if we already selected this exact system for this char:
       last_selected =
         WandererApp.Cache.lookup!(
           "char:#{character_id}:map:#{map_id}:last_selected_system_id",


### PR DESCRIPTION
- ensures system activity is updated on splash, and adds a delay on the signature deletion