### PR TITLE
fix (routes) fix query parameter formatting when calling esi routes endpoint

### DIFF
--- a/lib/wanderer_app/esi/api_client.ex
+++ b/lib/wanderer_app/esi/api_client.ex
@@ -401,12 +401,17 @@ defmodule WandererApp.Esi.ApiClient do
   defp _get_routes(origin, destination, params, opts),
     do: _get_routes_eve(origin, destination, params, opts)
 
-  defp _get_routes_eve(origin, destination, params, opts),
-    do:
-      get(
-        "/route/#{origin}/#{destination}/?#{params |> Plug.Conn.Query.encode()}",
-        opts
-      )
+  defp _get_routes_eve(origin, destination, params, opts) do
+    esi_params = Map.merge(params, %{
+      connections: params.connections |> Enum.join(","),
+      avoid: params.avoid |> Enum.join(",")
+    })
+
+    get(
+      "/route/#{origin}/#{destination}/?#{esi_params |> Plug.Conn.Query.encode()}",
+      opts
+    )
+  end
 
   defp get_auth_opts(opts), do: [auth: {:bearer, opts[:access_token]}]
 


### PR DESCRIPTION
ESI doesn't handle `array[]=value` formatted query parameters.