### PR TITLE
fix: remove error on websocket reconnect

### DIFF
--- a/lib/wanderer_app/zkb/zkb_kills_preloader.ex
+++ b/lib/wanderer_app/zkb/zkb_kills_preloader.ex
@@ -162,7 +162,7 @@ defmodule WandererApp.Zkb.KillsPreloader do
       "[KillsPreloader] Starting #{pass_type} pass => #{length(unique_systems)} systems"
     )
 
-    {final_state, kills_map} =
+    {final_state, _kills_map} =
       unique_systems
       |> Task.async_stream(
         fn {_map_id, system_id} ->

--- a/lib/wanderer_app/zkb/zkb_supervisor.ex
+++ b/lib/wanderer_app/zkb/zkb_supervisor.ex
@@ -23,7 +23,9 @@ defmodule WandererApp.Zkb.Supervisor do
           },
           opts: [
             name: {:local, :zkb_kills_provider},
-            mint_upgrade_opts: [Mint.WebSocket.PerMessageDeflate]
+            reconnect: true,
+            reconnect_after: 5_000,
+            max_reconnects: :infinity
           ]
         },
         preloader_child

--- a/lib/wanderer_app/zkb/zkills_provider/websocket.ex
+++ b/lib/wanderer_app/zkb/zkills_provider/websocket.ex
@@ -11,7 +11,6 @@ defmodule WandererApp.Zkb.KillsProvider.Websocket do
   use Retry
 
   @heartbeat_interval 1_000
-  @max_esi_retries 3
 
   # Called by `KillsProvider.handle_connect`
   def handle_connect(_status, _headers, %{connected: _} = state) do


### PR DESCRIPTION
removes this error


22:02:05.403 application=fresh module=Fresh.Log function=log/4 line=22 [error] (Fresh) Casting message failed: %Mint.TransportError{reason: :closed}
22:02:05.403 application=fresh module=Fresh.Log function=log/4 line=22 [error] (Fresh) Casting message failed: %Mint.TransportError{reason: :closed}
22:02:05.810 application=fresh module=Fresh.Log function=log/4 line=22 [error] (Fresh) Creating new stream for connection failed: %Mint.TransportError{reason: :closed}
22:02:06.404 application=wanderer_app module=WandererApp.Zkb.KillsProvider.Websocket function=handle_terminate/2 line=63 [warning] [KillsProvider.Websocket] Terminating => {:badkey, :extensions, nil}
22:02:06.404 module=gen_statem function=error_info/7 line=4975 [error] :gen_statem :zkb_kills_provider terminating
** (KeyError) key :extensions not found in: nil

If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
    (mint_web_socket 1.0.4) lib/mint/web_socket/frame.ex:103: Mint.WebSocket.Frame.encode/2
    (fresh 0.4.4) lib/fresh/connection.ex:221: Fresh.Connection.send_frame/2
    (fresh 0.4.4) lib/fresh/connection.ex:280: Fresh.Connection.handle_generic_callback/2
    (fresh 0.4.4) lib/fresh/connection.ex:139: Fresh.Connection.connected/3
    (stdlib 6.2.2) gen_statem.erl:3735: :gen_statem.loop_state_callback/11
    (stdlib 6.2.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
Queue: [info: :heartbeat]
Postponed: []