### PR TITLE
fix: fixed anomalies shown as "unscanned" in ru localization but correctly filtered.

### DIFF
--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/constants.ts
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/constants.ts
@@ -81,7 +81,7 @@ export const MAPPING_TYPE_TO_ENG = {
 export const getGroupIdByRawGroup = (val: string) => MAPPING_GROUP_TO_ENG[val as SignatureGroup];
 
 export const SIGNATURE_WINDOW_ID = 'system_signatures_window';
-export const SIGNATURE_SETTING_STORE_KEY = 'wanderer_system_signature_settings_v6_5';
+export const SIGNATURE_SETTING_STORE_KEY = 'wanderer_system_signature_settings_v6_6';
 
 export enum SETTINGS_KEYS {
   SHOW_DESCRIPTION_COLUMN = 'show_description_column',
@@ -109,6 +109,14 @@ export enum SETTINGS_KEYS {
   ORE_SITE = SignatureGroup.OreSite,
   GAS_SITE = SignatureGroup.GasSite,
   COMBAT_SITE = SignatureGroup.CombatSite,
+
+  // From RU Signature group
+  WORMHOLE_RU = SignatureGroupRU.Wormhole,
+  RELIC_SITE_RU = SignatureGroupRU.RelicSite,
+  DATA_SITE_RU = SignatureGroupRU.DataSite,
+  ORE_SITE_RU = SignatureGroupRU.OreSite,
+  GAS_SITE_RU = SignatureGroupRU.GasSite,
+  COMBAT_SITE_RU = SignatureGroupRU.CombatSite,
 }
 
 export enum SettingsTypes {
@@ -201,6 +209,14 @@ export const SETTINGS_VALUES: SignatureSettingsType = {
   [SETTINGS_KEYS.ORE_SITE]: true,
   [SETTINGS_KEYS.GAS_SITE]: true,
   [SETTINGS_KEYS.COMBAT_SITE]: true,
+
+  // Localization titles
+  [SETTINGS_KEYS.WORMHOLE_RU]: true,
+  [SETTINGS_KEYS.RELIC_SITE_RU]: true,
+  [SETTINGS_KEYS.DATA_SITE_RU]: true,
+  [SETTINGS_KEYS.ORE_SITE_RU]: true,
+  [SETTINGS_KEYS.GAS_SITE_RU]: true,
+  [SETTINGS_KEYS.COMBAT_SITE_RU]: true,
 };
 
 export const SIGNATURE_DELETION_TIMEOUTS: SignatureDeletionTimingType = {

--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/helpers/rowStyles.ts
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/helpers/rowStyles.ts
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { ExtendedSystemSignature, SignatureGroup } from '@/hooks/Mapper/types';
+import { ExtendedSystemSignature, SignatureGroup, SignatureGroupRU } from '@/hooks/Mapper/types';
 import { getRowBackgroundColor } from './getRowBackgroundColor';
 import classes from './rowStyles.module.scss';
 
@@ -28,14 +28,21 @@ export function getSignatureRowClass(
   if (colorByType) {
     switch (row.group) {
       case SignatureGroup.CosmicSignature:
+      case SignatureGroupRU.CosmicSignature:
         return clsx([...baseCls, '[&_td:nth-child(-n+3)]:text-rose-400 [&_td:nth-child(-n+3)]:hover:text-rose-300']);
       case SignatureGroup.Wormhole:
+      case SignatureGroupRU.Wormhole:
         return clsx([...baseCls, '[&_td:nth-child(-n+3)]:text-sky-300 [&_td:nth-child(-n+3)]:hover:text-sky-200']);
       case SignatureGroup.CombatSite:
       case SignatureGroup.RelicSite:
       case SignatureGroup.DataSite:
       case SignatureGroup.GasSite:
       case SignatureGroup.OreSite:
+      case SignatureGroupRU.CombatSite:
+      case SignatureGroupRU.RelicSite:
+      case SignatureGroupRU.DataSite:
+      case SignatureGroupRU.GasSite:
+      case SignatureGroupRU.OreSite:
         return clsx([...baseCls, '[&_td:nth-child(-n+4)]:text-lime-400 [&_td:nth-child(-n+4)]:hover:text-lime-300']);
     }
 

--- a/assets/js/hooks/Mapper/types/signatures.ts
+++ b/assets/js/hooks/Mapper/types/signatures.ts
@@ -41,7 +41,7 @@ export type SystemSignature = {
   // SignatureCustomInfo
   custom_info?: string;
   description?: string;
-  group: SignatureGroup;
+  group: SignatureGroup | SignatureGroupRU;
   type: string;
   linked_system?: SolarSystemStaticInfoRaw;
   inserted_at?: string;


### PR DESCRIPTION
Fixed error, when you are scanning down signature in RU localization they are correctly filtered (thanks to v1.52.4), but still showed down as "red", which means "unscanned" even they are scanned down.

TODO: gather all signature titles (which can be done easily by trying to create new filter in probes window) and create a function which will find the name in localized features