### PR TITLE
Add tooltips to the SolarSystemNodes

### DIFF
--- a/assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeDefault.tsx
+++ b/assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeDefault.tsx
@@ -10,13 +10,14 @@ import {
   MARKER_BOOKMARK_BG_STYLES,
   STATUS_CLASSES,
 } from '@/hooks/Mapper/components/map/constants';
-import { WormholeClassComp } from '@/hooks/Mapper/components/map/components/WormholeClassComp';
 import { UnsplashedSignature } from '@/hooks/Mapper/components/map/components/UnsplashedSignature';
 import { TooltipSize } from '@/hooks/Mapper/components/ui-kit/WdTooltipWrapper/utils.ts';
-import { TooltipPosition, WdTooltipWrapper } from '@/hooks/Mapper/components/ui-kit';
+import { FixedTooltip, TooltipPosition, WdTooltipWrapper, WHClassView } from '@/hooks/Mapper/components/ui-kit';
 import { Tag } from 'primereact/tag';
 import { LocalCounter } from '@/hooks/Mapper/components/map/components/LocalCounter';
 import { KillsCounter } from '@/hooks/Mapper/components/map/components/KillsCounter';
+import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
+import { EffectRaw } from '@/hooks/Mapper/types/effect';
 
 // let render = 0;
 export const SolarSystemNodeDefault = memo((props: NodeProps<MapSolarSystemType>) => {
@@ -26,7 +27,44 @@ export const SolarSystemNodeDefault = memo((props: NodeProps<MapSolarSystemType>
     nodeVars.solarSystemId,
   );
 
-  // console.log('JOipP', `render ${nodeVars.id}`, render++);
+  const {
+    data: { effects },
+  } = useMapRootState();
+
+  const prepareEffects = (effectsMap: Record<string, EffectRaw>, effectName: string, effectPower: number) => {
+    const effect = effectsMap[effectName];
+    if (!effect) return [] as { name: string; power: string; positive: boolean }[];
+    const out: { name: string; power: string; positive: boolean }[] = [];
+    effect.modifiers.map(mod => {
+      const modPower = mod.power[effectPower - 1];
+      out.push({ name: mod.name, power: modPower, positive: mod.positive });
+    });
+    out.sort((a, b) => (a.positive === b.positive ? 0 : a.positive ? -1 : 1));
+    return out;
+  };
+
+  const targetClass = `wh-effect-node-${nodeVars.id}`;
+
+  const renderEffectTooltip = () => {
+    if (!nodeVars.effectName || !nodeVars.isWormhole || !nodeVars.effectPower) {
+      return null;
+    }
+
+    return (
+      <FixedTooltip target={`.${targetClass}`} position="right" mouseTrack mouseTrackLeft={20} mouseTrackTop={30}>
+        <div className={clsx('grid grid-cols-[1fr_auto] gap-x-4 gap-y-1 text-xs p-1')}>
+          {prepareEffects(effects, nodeVars.effectName, nodeVars.effectPower).map(({ name, power, positive }) => (
+            <>
+              <span key={name + '-n'}>{name}</span>
+              <span key={name + '-p'} className={clsx({ 'text-green-500': positive, 'text-red-500': !positive })}>
+                {power}
+              </span>
+            </>
+          ))}
+        </div>
+      </FixedTooltip>
+    );
+  };
 
   return (
     <>
@@ -114,14 +152,23 @@ export const SolarSystemNodeDefault = memo((props: NodeProps<MapSolarSystemType>
               {nodeVars.isWormhole && (
                 <div className={classes.statics}>
                   {nodeVars.sortedStatics.map(whClass => (
-                    <WormholeClassComp key={String(whClass)} id={String(whClass)} />
+                    <WHClassView key={String(whClass)} whClassName={String(whClass)} hideWhClassName showRigRow />
                   ))}
                 </div>
               )}
 
               {nodeVars.effectName !== null && nodeVars.isWormhole && (
-                <div className={clsx(classes.effect, EFFECT_BACKGROUND_STYLES[nodeVars.effectName])} />
+                <div
+                  className={clsx(
+                    classes.effect,
+                    EFFECT_BACKGROUND_STYLES[nodeVars.effectName],
+                    targetClass,
+                    'cursor-help',
+                  )}
+                />
               )}
+
+              {renderEffectTooltip()}
             </div>
 
             <div className={clsx(classes.BottomRow, 'flex items-center justify-between')}>

--- a/assets/js/hooks/Mapper/components/map/hooks/useSolarSystemNode.ts
+++ b/assets/js/hooks/Mapper/components/map/hooks/useSolarSystemNode.ts
@@ -34,6 +34,7 @@ export interface SolarSystemNodeVars {
   dbClick: (event: React.MouseEvent<HTMLDivElement>) => void;
   sortedStatics: Array<string | number>;
   effectName: string | null;
+  effectPower?: number | null;
   regionName: string | null;
   solarSystemId: string;
   solarSystemName: string | null;
@@ -101,6 +102,7 @@ export const useSolarSystemNode = (props: NodeProps<MapSolarSystemType>): SolarS
     class_title,
     statics,
     effect_name,
+    effect_power,
     region_name,
     region_id,
     is_shattered,
@@ -217,6 +219,7 @@ export const useSolarSystemNode = (props: NodeProps<MapSolarSystemType>): SolarS
     dbClick,
     sortedStatics,
     effectName: effect_name,
+    effectPower: effect_power,
     solarSystemId: solar_system_id.toString(),
     locked,
     hubs: hubsAsStrings,

--- a/assets/js/hooks/Mapper/components/ui-kit/WHClassView/WHClassView.module.scss
+++ b/assets/js/hooks/Mapper/components/ui-kit/WHClassView/WHClassView.module.scss
@@ -15,7 +15,7 @@
   position: relative;
   font-size: 10px;
   font-weight: bold;
-  top: -2px;
+  top: -1px;
 }
 
 .NoOffset {

--- a/assets/js/hooks/Mapper/components/ui-kit/WHClassView/WHClassView.tsx
+++ b/assets/js/hooks/Mapper/components/ui-kit/WHClassView/WHClassView.tsx
@@ -24,6 +24,7 @@ export interface WHClassViewProps {
   highlightName?: boolean;
   className?: string;
   classNameWh?: string;
+  showRigRow?: boolean;
 }
 
 export const WHClassView = ({
@@ -36,6 +37,7 @@ export const WHClassView = ({
   highlightName,
   className,
   classNameWh,
+  showRigRow = false,
 }: WHClassViewProps) => {
   const {
     data: { wormholesData },
@@ -58,12 +60,27 @@ export const WHClassView = ({
           mouseTrackTop={30}
           className="border border-green-300 rounded border-opacity-10 bg-stone-900 bg-opacity-90 "
         >
+          {showRigRow && (
+            <div className="flex gap-3 mb-1">
+              <div className="flex flex-col gap-1 basis-1/2 shrink-0">
+                <InfoDrawer title="Signature">{whClassName}</InfoDrawer>
+              </div>
+              <div className="flex flex-col gap-1 basis-1/2 shrink-0">
+                <InfoDrawer title="Class">
+                  <span className={clsx(classes.WHClassName, whClassStyle, classNameWh)}>
+                    {useShortTitle ? whClass.shortTitle : whClass.shortName}
+                  </span>
+                </InfoDrawer>
+              </div>
+            </div>
+          )}
+
           <div className="flex gap-3">
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-1 basis-1/2 shrink-0">
               <InfoDrawer title="Total mass">{prepareMass(whData.total_mass)}</InfoDrawer>
               <InfoDrawer title="Jump mass">{prepareMass(whData.max_mass_per_jump)}</InfoDrawer>
             </div>
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-1 basis-1/2 shrink-0">
               <InfoDrawer title="Lifetime">{whData.lifetime}h</InfoDrawer>
               <InfoDrawer title="Mass regen">{prepareMass(whData.mass_regen)}</InfoDrawer>
             </div>


### PR DESCRIPTION
The goal of the PR is to add tooltips on a node for effect and statics. 
Majority of the work is done via the WHClassView which has been added to the SolarSystemNodeDefault. 