### PR TITLE
fix: remove actor context requirement from sig api

### DIFF
--- a/lib/wanderer_app/map/operations/signatures.ex
+++ b/lib/wanderer_app/map/operations/signatures.ex
@@ -78,7 +78,8 @@ defmodule WandererApp.Map.Operations.Signatures do
       )
       when is_integer(solar_system_id) do
     with {:ok, validated_char_uuid} <- validate_character_eve_id(params, char_id),
-         {:ok, system} <- MapSystem.by_map_id_and_solar_system_id(map_id, solar_system_id) do
+         {:ok, system} <-
+           MapSystem.read_by_map_and_solar_system(%{map_id: map_id, solar_system_id: solar_system_id}) do
       attrs =
         params
         |> Map.put("system_id", system.id)


### PR DESCRIPTION
 ## Summary
  - Fix `system_not_found` error when creating signatures via the HTTP API
  - The `create_signature` function was using `MapSystem.by_map_id_and_solar_system_id()` which relies on the `:read` action with `FilterSystemsByActorMap` preparation that requires actor context
  - Changed to use `read_by_map_and_solar_system()` which uses explicit argument-based filtering instead

  ## Test plan
  - [ ] Create a signature via API: `POST /api/maps/{slug}/signatures`
  - [ ] Verify signature appears in list: `GET /api/maps/{slug}/signatures`
  - [ ] Update signature: `PUT /api/maps/{slug}/signatures/{id}`
  - [ ] Delete signature: `DELETE /api/maps/{slug}/signatures/{id}`