### PR TITLE
fix: use cache for sse

### DIFF
--- a/lib/wanderer_app/api/map.ex
+++ b/lib/wanderer_app/api/map.ex
@@ -218,6 +218,11 @@ defmodule WandererApp.Api.Map do
     update :toggle_webhooks do
       accept [:webhooks_enabled]
       require_atomic? false
+
+      change after_action(fn _changeset, record, _context ->
+               WandererApp.Map.update_webhooks_enabled(record.id, record.webhooks_enabled)
+               {:ok, record}
+             end)
     end
 
     update :toggle_sse do
@@ -226,6 +231,11 @@ defmodule WandererApp.Api.Map do
 
       # Validate subscription when enabling SSE
       validate &validate_sse_subscription/2
+
+      change after_action(fn _changeset, record, _context ->
+               WandererApp.Map.update_sse_enabled(record.id, record.sse_enabled)
+               {:ok, record}
+             end)
     end
 
     create :duplicate do

--- a/lib/wanderer_app/application.ex
+++ b/lib/wanderer_app/application.ex
@@ -86,6 +86,11 @@ defmodule WandererApp.Application do
       Supervisor.child_spec({Cachex, name: :wanderer_app_cache},
         id: :wanderer_app_cache_worker
       ),
+      # Cache for webhook subscriptions - 5 minute TTL to reduce DB load
+      Supervisor.child_spec(
+        {Cachex, name: :webhook_subscriptions_cache, default_ttl: :timer.minutes(5)},
+        id: :webhook_subscriptions_cache_worker
+      ),
       {Registry, keys: :unique, name: WandererApp.Character.TrackerRegistry},
       {PartitionSupervisor,
        child_spec: DynamicSupervisor, name: WandererApp.Character.DynamicSupervisors},


### PR DESCRIPTION
  Fixes database connection pool exhaustion caused by SSE/webhook system making 4+ DB queries per event broadcast.                                                                        
                                                                                                                                                                                          
  Root cause: Every external event triggered multiple database queries:                                                                                                                   
  - Api.Map.by_id() to check webhooks_enabled                                                                                                                                             
  - MapWebhookSubscription.active_by_map!() to fetch subscriptions                                                                                                                        
  - Api.Map.by_id() to check sse_enabled                                                                                                                                                  
  - MapSubscriptionRepo.get_active_by_map() to check subscription status                                                                                                                  
                                                                                                                                                                                          
  At 100 events/second, this resulted in 400+ DB queries/second just for external event checks.                                                                                           
                                                                                                                                                                                          
  Solution: Use cached data instead of DB queries:                                                                                                                                        
  - Added sse_enabled, webhooks_enabled, and subscription_plan to the Map cache struct                                                                                                    
  - Added webhook subscriptions cache with 5-minute TTL                                                                                                                                   
  - Updated WebhookDispatcher and SseAccessControl to use cached data                                                                                                                     
  - Added cache invalidation hooks on settings changes                                                                                                                                    
                                                                                                                                                                                          
  Changes                                                                                                                                                                                 
                                                                                                                                                                                          
  - lib/wanderer_app/map.ex - Added SSE/webhook/subscription fields to Map struct and cache helper functions                                                                              
  - lib/wanderer_app/application.ex - Added :webhook_subscriptions_cache                                                                                                                  
  - lib/wanderer_app/api/map.ex - Added cache invalidation hooks to toggle actions                                                                                                        
  - lib/wanderer_app/api/map_webhook_subscription.ex - Added cache invalidation on CRUD                                                                                                   
  - lib/wanderer_app/external_events/webhook_dispatcher.ex - Use cached map settings and subscription lookups                                                                             
  - lib/wanderer_app/external_events/sse_access_control.ex - Rewritten to use cached data with DB fallback                                                                                
                                                                                                                                                                                          