### PR TITLE
feat: add plugin configuration system

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -476,3 +476,22 @@ config :wanderer_app, :external_events,
     |> get_var_from_path_or_env("WANDERER_WEBHOOKS_ENABLED", "false")
     |> String.to_existing_atom(),
   webhook_timeout_ms: config_dir |> get_int_from_path_or_env("WANDERER_WEBHOOK_TIMEOUT_MS", 15000)
+
+# Plugin System Configuration
+plugins_enabled =
+  config_dir
+  |> get_var_from_path_or_env("WANDERER_PLUGINS_ENABLED", "false")
+  |> String.to_existing_atom()
+
+notifier_api_key =
+  config_dir
+  |> get_var_from_path_or_env("WANDERER_PLUGIN_NOTIFIER_API_KEY", "")
+  |> String.trim()
+
+if plugins_enabled and notifier_api_key == "" do
+  raise "WANDERER_PLUGIN_NOTIFIER_API_KEY must be set when plugins are enabled"
+end
+
+config :wanderer_app, :plugins,
+  enabled: plugins_enabled,
+  api_keys: %{"notifier" => notifier_api_key}

--- a/lib/wanderer_app/api.ex
+++ b/lib/wanderer_app/api.ex
@@ -38,5 +38,6 @@ defmodule WandererApp.Api do
     resource WandererApp.Api.MapPing
     resource WandererApp.Api.MapInvite
     resource WandererApp.Api.MapWebhookSubscription
+    resource WandererApp.Api.MapPluginConfig
   end
 end

--- a/lib/wanderer_app/api/map.ex
+++ b/lib/wanderer_app/api/map.ex
@@ -66,6 +66,8 @@ defmodule WandererApp.Api.Map do
       action: :read
     )
 
+    define(:by_ids, action: :by_ids, args: [:ids])
+
     define(:duplicate, action: :duplicate)
     define(:admin_all, action: :admin_all)
     define(:restore, action: :restore)
@@ -90,6 +92,14 @@ defmodule WandererApp.Api.Map do
 
   actions do
     defaults [:create, :read, :destroy]
+
+    read :by_ids do
+      argument :ids, {:array, :uuid},
+        allow_nil?: false,
+        constraints: [min_length: 1, max_length: 100]
+
+      filter expr(id in ^arg(:ids))
+    end
 
     read :by_slug do
       get? true

--- a/lib/wanderer_app/api/map_plugin_config.ex
+++ b/lib/wanderer_app/api/map_plugin_config.ex
@@ -1,0 +1,146 @@
+defmodule WandererApp.Api.MapPluginConfig do
+  @moduledoc """
+  Ash resource for storing per-map plugin configuration.
+
+  Each map can have one config per plugin. The config field is encrypted at rest
+  (via AshCloak) since it may contain sensitive data like Discord bot tokens.
+  """
+
+  use Ash.Resource,
+    domain: WandererApp.Api,
+    data_layer: AshPostgres.DataLayer,
+    extensions: [AshCloak]
+
+  postgres do
+    repo(WandererApp.Repo)
+    table("map_plugin_configs_v1")
+  end
+
+  cloak do
+    vault(WandererApp.Vault)
+    attributes([:config])
+    decrypt_by_default([:config])
+  end
+
+  code_interface do
+    define(:create, action: :create)
+    define(:update, action: :update)
+    define(:destroy, action: :destroy)
+
+    define(:by_id,
+      get_by: [:id],
+      action: :read
+    )
+
+    define(:by_map_and_plugin, action: :by_map_and_plugin, args: [:map_id, :plugin_name])
+    define(:enabled_by_plugin, action: :enabled_by_plugin, args: [:plugin_name])
+    define(:by_map, action: :by_map, args: [:map_id])
+  end
+
+  actions do
+    default_accept [
+      :map_id,
+      :plugin_name,
+      :enabled,
+      :config
+    ]
+
+    defaults [:read, :destroy]
+
+    create :create do
+      accept [
+        :map_id,
+        :plugin_name,
+        :enabled,
+        :config
+      ]
+
+      change fn changeset, _context ->
+        plugin_name = Ash.Changeset.get_attribute(changeset, :plugin_name)
+
+        if WandererApp.Plugins.PluginRegistry.plugin_exists?(plugin_name) do
+          changeset
+        else
+          Ash.Changeset.add_error(changeset,
+            field: :plugin_name,
+            message: "unknown plugin: #{plugin_name}"
+          )
+        end
+      end
+    end
+
+    update :update do
+      accept [
+        :enabled,
+        :config
+      ]
+
+      require_atomic? false
+
+      # Auto-increment config_version on every update
+      change fn changeset, _context ->
+        current_version = changeset.data.config_version
+        Ash.Changeset.force_change_attribute(changeset, :config_version, current_version + 1)
+      end
+    end
+
+    read :by_map_and_plugin do
+      argument :map_id, :uuid, allow_nil?: false
+      argument :plugin_name, :string, allow_nil?: false
+      get? true
+      filter expr(map_id == ^arg(:map_id) and plugin_name == ^arg(:plugin_name))
+    end
+
+    read :enabled_by_plugin do
+      argument :plugin_name, :string, allow_nil?: false
+      filter expr(plugin_name == ^arg(:plugin_name) and enabled == true)
+    end
+
+    read :by_map do
+      argument :map_id, :uuid, allow_nil?: false
+      filter expr(map_id == ^arg(:map_id))
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :map_id, :uuid do
+      allow_nil? false
+    end
+
+    attribute :plugin_name, :string do
+      allow_nil? false
+    end
+
+    attribute :enabled, :boolean do
+      allow_nil? false
+      default false
+    end
+
+    attribute :config, :string do
+      allow_nil? true
+      sensitive? true
+    end
+
+    attribute :config_version, :integer do
+      allow_nil? false
+      default 1
+    end
+
+    create_timestamp(:inserted_at)
+    update_timestamp(:updated_at)
+  end
+
+  relationships do
+    belongs_to :map, WandererApp.Api.Map do
+      source_attribute :map_id
+      destination_attribute :id
+      attribute_writable? true
+    end
+  end
+
+  identities do
+    identity :unique_map_plugin, [:map_id, :plugin_name]
+  end
+end

--- a/lib/wanderer_app/env.ex
+++ b/lib/wanderer_app/env.ex
@@ -93,6 +93,11 @@ defmodule WandererApp.Env do
     |> Keyword.get(:webhooks_enabled, false)
   end
 
+  def plugins_enabled?() do
+    Application.get_env(@app, :plugins, [])
+    |> Keyword.get(:enabled, false)
+  end
+
   @decorate cacheable(
               cache: WandererApp.Cache,
               key: "map-connection-auto-expire-hours"

--- a/lib/wanderer_app/plugins/plugin_registry.ex
+++ b/lib/wanderer_app/plugins/plugin_registry.ex
@@ -1,0 +1,173 @@
+defmodule WandererApp.Plugins.PluginRegistry do
+  @moduledoc """
+  Fixed catalog of known plugins. Plugins are defined in code, not in the database.
+  Adding a new plugin requires a code change to this module.
+  """
+
+  require Logger
+
+  @plugins %{
+    "notifier" => %{
+      name: "notifier",
+      display_name: "Discord Notifier",
+      description:
+        "Sends map events (kills, new systems, characters, rallies) to Discord channels",
+      requires_subscription: true
+    }
+  }
+
+  @notifier_default_config %{
+    "discord" => %{
+      "bot_token" => "",
+      "channels" => %{
+        "primary" => "",
+        "system_kill" => nil,
+        "character_kill" => nil,
+        "system" => nil,
+        "character" => nil,
+        "rally" => nil
+      },
+      "rally_group_ids" => []
+    },
+    "features" => %{
+      "notifications_enabled" => true,
+      "kill_notifications_enabled" => true,
+      "system_notifications_enabled" => true,
+      "character_notifications_enabled" => true,
+      "rally_notifications_enabled" => true,
+      "wormhole_only_kill_notifications" => false,
+      "track_kspace" => true,
+      "priority_systems_only" => false
+    },
+    "settings" => %{
+      "corporation_kill_focus" => [],
+      "character_exclude_list" => [],
+      "system_exclude_list" => []
+    }
+  }
+
+  @spec list_plugins() :: [map()]
+  def list_plugins, do: Map.values(@plugins)
+
+  @spec get_plugin(String.t()) :: map() | nil
+  def get_plugin(name), do: Map.get(@plugins, name)
+
+  @spec plugin_exists?(String.t()) :: boolean()
+  def plugin_exists?(name), do: Map.has_key?(@plugins, name)
+
+  @spec plugin_names() :: [String.t()]
+  def plugin_names, do: Map.keys(@plugins)
+
+  @spec default_config(String.t()) :: map() | nil
+  def default_config("notifier"), do: @notifier_default_config
+  def default_config(_), do: nil
+
+  @spec parse_config_json(nil | String.t()) :: map()
+  def parse_config_json(nil), do: %{}
+  def parse_config_json(""), do: %{}
+
+  def parse_config_json(json) when is_binary(json) do
+    case Jason.decode(json) do
+      {:ok, parsed} ->
+        parsed
+
+      {:error, error} ->
+        Logger.warning(
+          "Failed to decode plugin config JSON: #{inspect(error)}, input: #{String.slice(json, 0, 200)}"
+        )
+
+        %{}
+    end
+  end
+
+  @spec validate_config(String.t(), map()) :: {:ok, map()} | {:error, [String.t()]}
+  def validate_config("notifier", config) when is_map(config) do
+    with :ok <- validate_top_level_types(config),
+         :ok <- validate_nested_types(config),
+         :ok <- validate_required_fields(config) do
+      {:ok, normalize_notifier_config(config)}
+    end
+  end
+
+  def validate_config(plugin_name, _config) do
+    if plugin_exists?(plugin_name),
+      do: {:error, ["config must be a map"]},
+      else: {:error, ["unknown plugin: #{plugin_name}"]}
+  end
+
+  defp validate_top_level_types(config) do
+    errors =
+      []
+      |> check_is_map(Map.get(config, "discord", %{}), "discord must be a map")
+      |> check_is_map(Map.get(config, "features", %{}), "features must be a map")
+      |> check_is_map(Map.get(config, "settings", %{}), "settings must be a map")
+
+    if errors == [], do: :ok, else: {:error, Enum.reverse(errors)}
+  end
+
+  defp validate_nested_types(config) do
+    discord = Map.get(config, "discord", %{})
+
+    errors =
+      []
+      |> check_is_map(Map.get(discord, "channels", %{}), "discord.channels must be a map")
+
+    if errors == [], do: :ok, else: {:error, Enum.reverse(errors)}
+  end
+
+  defp validate_required_fields(config) do
+    discord = Map.get(config, "discord", %{})
+
+    errors =
+      []
+      |> require_non_blank(Map.get(discord, "bot_token"), "discord.bot_token is required")
+      |> require_non_blank(
+        get_in(discord, ["channels", "primary"]),
+        "discord.channels.primary is required"
+      )
+
+    if errors == [], do: :ok, else: {:error, Enum.reverse(errors)}
+  end
+
+  defp normalize_notifier_config(config) do
+    default = @notifier_default_config
+    discord = ensure_map(Map.get(config, "discord"), Map.get(default, "discord"))
+    channels = ensure_map(Map.get(discord, "channels"), get_in(default, ["discord", "channels"]))
+    features = ensure_map(Map.get(config, "features"), Map.get(default, "features"))
+    settings = ensure_map(Map.get(config, "settings"), Map.get(default, "settings"))
+
+    normalized_discord = %{
+      "bot_token" => Map.get(discord, "bot_token", ""),
+      "channels" => Map.merge(get_in(default, ["discord", "channels"]), channels),
+      "rally_group_ids" => ensure_list(Map.get(discord, "rally_group_ids", []))
+    }
+
+    normalized_features = Map.merge(Map.get(default, "features"), features)
+    normalized_settings = Map.merge(Map.get(default, "settings"), settings)
+
+    %{
+      "discord" => normalized_discord,
+      "features" => normalized_features,
+      "settings" => normalized_settings
+    }
+  end
+
+  defp require_non_blank(errors, value, message) do
+    if is_binary(value) and String.trim(value) != "",
+      do: errors,
+      else: [message | errors]
+  end
+
+  defp check_is_map(errors, value, message) do
+    if is_map(value),
+      do: errors,
+      else: [message | errors]
+  end
+
+  defp ensure_map(value, _default) when is_map(value), do: value
+  defp ensure_map(_value, default) when is_map(default), do: default
+  defp ensure_map(_value, _default), do: %{}
+
+  defp ensure_list(value) when is_list(value), do: value
+  defp ensure_list(_), do: []
+end

--- a/lib/wanderer_app/plugins/plugins.ex
+++ b/lib/wanderer_app/plugins/plugins.ex
@@ -1,0 +1,22 @@
+defmodule WandererApp.Plugins do
+  @moduledoc """
+  Server-wide plugin configuration. Reads from application environment
+  (set via environment variables in runtime.exs).
+
+  Provides helper functions for accessing plugin-level settings such as API keys.
+  """
+
+  @spec get_api_key(String.t()) :: {:ok, String.t()} | {:error, :no_api_key}
+  def get_api_key(plugin_name) do
+    keys =
+      Application.get_env(:wanderer_app, :plugins, [])
+      |> Keyword.get(:api_keys, %{})
+
+    case Map.get(keys, plugin_name) do
+      nil -> {:error, :no_api_key}
+      "" -> {:error, :no_api_key}
+      key when is_binary(key) -> {:ok, key}
+      _ -> {:error, :no_api_key}
+    end
+  end
+end

--- a/lib/wanderer_app_web/controllers/plugin_config_api_controller.ex
+++ b/lib/wanderer_app_web/controllers/plugin_config_api_controller.ex
@@ -1,0 +1,143 @@
+defmodule WandererAppWeb.PluginConfigApiController do
+  @moduledoc """
+  API controller for external bots to discover which maps have enabled their
+  plugin and retrieve configuration.
+
+  GET /api/plugins/:plugin_name/config
+  Authorization: Bearer {PLUGIN_API_KEY}
+  """
+
+  use WandererAppWeb, :controller
+
+  alias WandererApp.Api.MapPluginConfig
+  alias WandererApp.Plugins.PluginRegistry
+
+  require Logger
+
+  def show(conn, %{"plugin_name" => plugin_name}) do
+    plugin = PluginRegistry.get_plugin(plugin_name)
+
+    if is_nil(plugin) do
+      conn
+      |> put_status(404)
+      |> json(%{error: "Unknown plugin: #{plugin_name}"})
+    else
+      show_plugin_config(conn, plugin_name, plugin)
+    end
+  end
+
+  defp show_plugin_config(conn, plugin_name, plugin) do
+    case MapPluginConfig.enabled_by_plugin(plugin_name) do
+      {:ok, configs} ->
+        maps_by_id = load_maps_by_id(Enum.map(configs, & &1.map_id))
+
+        configs =
+          configs
+          |> filter_deleted_maps(maps_by_id)
+          |> maybe_filter_by_subscription(plugin)
+
+        {maps_data, version, updated_at} =
+          Enum.reduce(configs, {[], 0, nil}, fn config, {maps_acc, max_ver, max_at} ->
+            map_entry = build_map_response(config, maps_by_id)
+            maps_acc = if map_entry, do: [map_entry | maps_acc], else: maps_acc
+            max_ver = max(config.config_version, max_ver)
+
+            max_at =
+              case max_at do
+                nil -> config.updated_at
+                prev -> Enum.max([prev, config.updated_at], DateTime)
+              end
+
+            {maps_acc, max_ver, max_at}
+          end)
+
+        json(conn, %{
+          data: %{
+            maps: Enum.reverse(maps_data),
+            version: version,
+            updated_at: updated_at || DateTime.utc_now()
+          }
+        })
+
+      {:error, reason} ->
+        Logger.error("Failed to fetch plugin configs: #{inspect(reason)}")
+
+        conn
+        |> put_status(500)
+        |> json(%{error: "Internal server error"})
+    end
+  end
+
+  defp load_maps_by_id(map_ids) do
+    ids = Enum.uniq(map_ids)
+
+    case WandererApp.Api.Map.by_ids(ids, load: [:owner]) do
+      {:ok, maps} ->
+        Map.new(maps, fn map -> {map.id, map} end)
+
+      {:error, _reason} ->
+        %{}
+    end
+  end
+
+  defp filter_deleted_maps(configs, maps_by_id) do
+    Enum.filter(configs, fn config ->
+      case Map.get(maps_by_id, config.map_id) do
+        %{deleted: true} -> false
+        %{} -> true
+        nil -> false
+      end
+    end)
+  end
+
+  defp maybe_filter_by_subscription(configs, %{requires_subscription: true}) do
+    if WandererApp.Env.map_subscriptions_enabled?() do
+      Enum.filter(configs, fn config ->
+        case WandererApp.Map.is_subscription_active?(config.map_id) do
+          {:ok, true} -> true
+          _ -> false
+        end
+      end)
+    else
+      configs
+    end
+  end
+
+  defp maybe_filter_by_subscription(configs, _plugin), do: configs
+
+  defp build_map_response(config, maps_by_id) do
+    case Map.get(maps_by_id, config.map_id) do
+      nil ->
+        nil
+
+      map ->
+        parsed_config = PluginRegistry.parse_config_json(config.config)
+        owner_name = get_owner_display_name(map.owner)
+
+        %{
+          slug: map.slug,
+          name: map.name,
+          map_id: map.id,
+          owner: owner_name,
+          discord: Map.get(parsed_config, "discord", %{}),
+          features: Map.get(parsed_config, "features", %{}),
+          settings: Map.get(parsed_config, "settings", %{})
+        }
+    end
+  end
+
+  defp get_owner_display_name(nil), do: "Unknown"
+
+  defp get_owner_display_name(character) do
+    cond do
+      is_binary(character.alliance_name) and character.alliance_name != "" ->
+        character.alliance_name
+
+      is_binary(character.corporation_name) and character.corporation_name != "" ->
+        character.corporation_name
+
+      true ->
+        character.name
+    end
+  end
+end

--- a/lib/wanderer_app_web/controllers/plugs/check_plugin_api_key.ex
+++ b/lib/wanderer_app_web/controllers/plugs/check_plugin_api_key.ex
@@ -1,0 +1,74 @@
+defmodule WandererAppWeb.Plugs.CheckPluginApiKey do
+  @moduledoc """
+  Plug to authenticate plugin API requests using a per-plugin API key.
+
+  Each plugin type has one server-wide API key set via environment variable.
+  The bot provides this key as a Bearer token.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+  alias Plug.Crypto
+  require Logger
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    plugin_name = conn.params["plugin_name"]
+
+    with {:ok, _} <- valid_plugin?(plugin_name),
+         {:ok, expected_key} <- WandererApp.Plugins.get_api_key(plugin_name),
+         ["Bearer " <> token] <- get_req_header(conn, "authorization"),
+         true <- Crypto.secure_compare(expected_key, token) do
+      conn
+      |> assign(:plugin_name, plugin_name)
+    else
+      false ->
+        Logger.warning("Unauthorized: invalid token for plugin #{plugin_name}")
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(401, Jason.encode!(%{error: "Unauthorized (invalid token)"}))
+        |> halt()
+
+      {:error, :not_a_plugin} ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(404, Jason.encode!(%{error: "Unknown plugin: #{plugin_name}"}))
+        |> halt()
+
+      {:error, :no_api_key} ->
+        Logger.warning("Plugin #{plugin_name} has no API key configured")
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(503, Jason.encode!(%{error: "Plugin not configured on this server"}))
+        |> halt()
+
+      [] ->
+        Logger.warning("Missing Bearer token for plugin API")
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(401, Jason.encode!(%{error: "Missing or invalid Bearer token"}))
+        |> halt()
+
+      _ ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(401, Jason.encode!(%{error: "Unauthorized"}))
+        |> halt()
+    end
+  end
+
+  defp valid_plugin?(name) do
+    if WandererApp.Plugins.PluginRegistry.plugin_exists?(name) do
+      {:ok, name}
+    else
+      {:error, :not_a_plugin}
+    end
+  end
+end

--- a/lib/wanderer_app_web/controllers/plugs/check_webhooks_disabled.ex
+++ b/lib/wanderer_app_web/controllers/plugs/check_webhooks_disabled.ex
@@ -12,7 +12,13 @@ defmodule WandererAppWeb.Plugs.CheckWebhooksDisabled do
   def call(conn, _opts) do
     if not WandererApp.Env.webhooks_enabled?() do
       conn
-      |> send_resp(403, "Webhooks are disabled. Set WANDERER_WEBHOOKS_ENABLED=true to enable.")
+      |> put_resp_content_type("application/json")
+      |> send_resp(
+        403,
+        Jason.encode!(%{
+          error: "Webhooks are disabled. Set WANDERER_WEBHOOKS_ENABLED=true to enable."
+        })
+      )
       |> halt()
     else
       conn

--- a/lib/wanderer_app_web/controllers/plugs/require_plugins_enabled.ex
+++ b/lib/wanderer_app_web/controllers/plugs/require_plugins_enabled.ex
@@ -1,0 +1,32 @@
+defmodule WandererAppWeb.Plugs.RequirePluginsEnabled do
+  @moduledoc """
+  Plug that requires plugins to be enabled.
+
+  Blocks access to plugin endpoints when plugins are disabled.
+  Enable plugins by setting WANDERER_PLUGINS_ENABLED=true in your environment.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    if not WandererApp.Env.plugins_enabled?() do
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(
+        403,
+        Jason.encode!(%{
+          error: "Plugins are disabled. Set WANDERER_PLUGINS_ENABLED=true to enable."
+        })
+      )
+      |> halt()
+    else
+      conn
+    end
+  end
+end

--- a/lib/wanderer_app_web/live/maps/components/plugins_component.ex
+++ b/lib/wanderer_app_web/live/maps/components/plugins_component.ex
@@ -1,0 +1,691 @@
+defmodule WandererAppWeb.Maps.PluginsComponent do
+  @moduledoc """
+  LiveView component for managing plugin configuration on a map.
+
+  Displays available plugins, allows enabling/disabling, and provides
+  plugin-specific configuration forms.
+  """
+
+  use WandererAppWeb, :live_component
+  require Logger
+
+  alias WandererApp.Api.MapPluginConfig
+  alias WandererApp.Plugins.PluginRegistry
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+     assign(socket,
+       plugins: [],
+       configs: %{},
+       parsed_configs: %{},
+       loaded_map_id: nil,
+       loading: true,
+       error: nil,
+       saving: false,
+       show_bot_token: false,
+       show_advanced: false,
+       success_message: nil
+     )}
+  end
+
+  @impl true
+  def update(%{map_id: map_id} = assigns, socket) do
+    plugins = PluginRegistry.list_plugins()
+
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(plugins: plugins)
+
+    socket =
+      if socket.assigns.loaded_map_id != map_id do
+        socket
+        |> load_configs(map_id)
+        |> assign(loaded_map_id: map_id)
+      else
+        socket
+      end
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("toggle_plugin", %{"plugin" => plugin_name}, socket) do
+    map_id = socket.assigns.map_id
+    configs = socket.assigns.configs
+
+    case Map.get(configs, plugin_name) do
+      nil ->
+        default_config = PluginRegistry.default_config(plugin_name)
+
+        case MapPluginConfig.create(%{
+               map_id: map_id,
+               plugin_name: plugin_name,
+               enabled: true,
+               config: Jason.encode!(default_config)
+             }) do
+          {:ok, config} ->
+            {:noreply,
+             socket
+             |> put_config(plugin_name, config, default_config)
+             |> assign(success_message: "Plugin enabled", error: nil)}
+
+          {:error, reason} ->
+            Logger.error("Failed to enable plugin: #{inspect(reason)}")
+            {:noreply, assign(socket, error: "Failed to enable plugin")}
+        end
+
+      config ->
+        new_enabled = not config.enabled
+
+        case MapPluginConfig.update(config, %{enabled: new_enabled}) do
+          {:ok, updated} ->
+            message = if new_enabled, do: "Plugin enabled", else: "Plugin disabled"
+
+            {:noreply,
+             socket
+             |> put_config(plugin_name, updated)
+             |> assign(success_message: message, error: nil)}
+
+          {:error, reason} ->
+            Logger.error("Failed to toggle plugin: #{inspect(reason)}")
+            {:noreply, assign(socket, error: "Failed to update plugin")}
+        end
+    end
+  end
+
+  @impl true
+  def handle_event("toggle_bot_token", _, socket) do
+    {:noreply, assign(socket, show_bot_token: !socket.assigns.show_bot_token)}
+  end
+
+  @impl true
+  def handle_event("toggle_advanced", _, socket) do
+    {:noreply, assign(socket, show_advanced: !socket.assigns.show_advanced)}
+  end
+
+  @impl true
+  def handle_event("save_plugin_config", %{"plugin" => plugin_name} = params, socket) do
+    socket = assign(socket, saving: true)
+    config = Map.get(socket.assigns.configs, plugin_name)
+
+    if is_nil(config) do
+      {:noreply, assign(socket, saving: false, error: "Plugin not enabled")}
+    else
+      with {:ok, new_config} <- build_config_from_params(plugin_name, params),
+           {:ok, validated_config} <- PluginRegistry.validate_config(plugin_name, new_config),
+           {:ok, updated} <-
+             MapPluginConfig.update(config, %{config: Jason.encode!(validated_config)}) do
+        {:noreply,
+         socket
+         |> put_config(plugin_name, updated, validated_config)
+         |> assign(success_message: "Configuration saved", error: nil, saving: false)}
+      else
+        {:error, errors} when is_list(errors) ->
+          {:noreply, assign(socket, error: Enum.join(errors, ", "), saving: false)}
+
+        {:error, reason} ->
+          Logger.error("Failed to save plugin config: #{inspect(reason)}")
+          {:noreply, assign(socket, error: "Failed to save configuration", saving: false)}
+      end
+    end
+  end
+
+  @impl true
+  def handle_event("dismiss_message", _, socket) do
+    {:noreply, assign(socket, success_message: nil, error: nil)}
+  end
+
+  defp put_config(socket, plugin_name, config, parsed \\ nil) do
+    parsed = parsed || PluginRegistry.parse_config_json(config.config)
+
+    socket
+    |> assign(configs: Map.put(socket.assigns.configs, plugin_name, config))
+    |> assign(parsed_configs: Map.put(socket.assigns.parsed_configs, plugin_name, parsed))
+  end
+
+  defp load_configs(socket, map_id) do
+    case MapPluginConfig.by_map(map_id) do
+      {:ok, configs} ->
+        {configs_map, parsed_map} =
+          Enum.reduce(configs, {%{}, %{}}, fn c, {cm, pm} ->
+            {Map.put(cm, c.plugin_name, c),
+             Map.put(pm, c.plugin_name, PluginRegistry.parse_config_json(c.config))}
+          end)
+
+        assign(socket,
+          configs: configs_map,
+          parsed_configs: parsed_map,
+          loading: false,
+          error: nil
+        )
+
+      {:error, reason} ->
+        Logger.error("Failed to load plugin configs: #{inspect(reason)}")
+
+        assign(socket,
+          configs: %{},
+          parsed_configs: %{},
+          loading: false,
+          error: "Failed to load plugin settings"
+        )
+    end
+  end
+
+  defp build_config_from_params("notifier", params) do
+    int_fields = [
+      {"corporation_kill_focus", Map.get(params, "corporation_kill_focus", "")},
+      {"character_exclude_list", Map.get(params, "character_exclude_list", "")},
+      {"system_exclude_list", Map.get(params, "system_exclude_list", "")}
+    ]
+
+    {settings, errors} =
+      Enum.reduce(int_fields, {%{}, []}, fn {field, raw}, {settings, errors} ->
+        case parse_comma_list_int(raw) do
+          {:ok, ints} ->
+            {Map.put(settings, field, ints), errors}
+
+          {:error, invalid} ->
+            {Map.put(settings, field, []),
+             ["#{field}: invalid values: #{Enum.join(invalid, ", ")}" | errors]}
+        end
+      end)
+
+    config = %{
+      "discord" => %{
+        "bot_token" => Map.get(params, "bot_token", ""),
+        "channels" => %{
+          "primary" => Map.get(params, "channel_primary", ""),
+          "system_kill" => nilify(Map.get(params, "channel_system_kill", "")),
+          "character_kill" => nilify(Map.get(params, "channel_character_kill", "")),
+          "system" => nilify(Map.get(params, "channel_system", "")),
+          "character" => nilify(Map.get(params, "channel_character", "")),
+          "rally" => nilify(Map.get(params, "channel_rally", ""))
+        },
+        "rally_group_ids" => parse_comma_list(Map.get(params, "rally_group_ids", ""))
+      },
+      "features" => %{
+        "notifications_enabled" => params["notifications_enabled"] == "true",
+        "kill_notifications_enabled" => params["kill_notifications_enabled"] == "true",
+        "system_notifications_enabled" => params["system_notifications_enabled"] == "true",
+        "character_notifications_enabled" => params["character_notifications_enabled"] == "true",
+        "rally_notifications_enabled" => params["rally_notifications_enabled"] == "true",
+        "wormhole_only_kill_notifications" =>
+          params["wormhole_only_kill_notifications"] == "true",
+        "track_kspace" => params["track_kspace"] == "true",
+        "priority_systems_only" => params["priority_systems_only"] == "true"
+      },
+      "settings" => settings
+    }
+
+    case errors do
+      [] -> {:ok, config}
+      _ -> {:error, Enum.reverse(errors)}
+    end
+  end
+
+  defp build_config_from_params(_, _params), do: {:ok, %{}}
+
+  defp nilify(""), do: nil
+  defp nilify(val), do: val
+
+  defp parse_comma_list(""), do: []
+
+  defp parse_comma_list(str) when is_binary(str) do
+    str
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp parse_comma_list(_), do: []
+
+  defp parse_comma_list_int(str) do
+    {ints, invalid} =
+      str
+      |> parse_comma_list()
+      |> Enum.reduce({[], []}, fn s, {ints, invalid} ->
+        case Integer.parse(s) do
+          {n, _} -> {[n | ints], invalid}
+          :error -> {ints, [s | invalid]}
+        end
+      end)
+
+    case invalid do
+      [] -> {:ok, Enum.reverse(ints)}
+      _ -> {:error, Enum.reverse(invalid)}
+    end
+  end
+
+  defp config_val(parsed_configs, plugin_name, path, default) do
+    case Map.get(parsed_configs, plugin_name) do
+      nil -> default
+      parsed -> get_in(parsed, path) || default
+    end
+  end
+
+  defp enabled?(configs, plugin_name) do
+    case Map.get(configs, plugin_name) do
+      nil -> false
+      config -> config.enabled
+    end
+  end
+
+  defp comma_join(list) when is_list(list), do: Enum.join(list, ", ")
+  defp comma_join(_), do: ""
+
+  defp plugin_checkbox(assigns) do
+    ~H"""
+    <label class="flex items-center gap-2 cursor-pointer py-1">
+      <input type="hidden" name={@name} value="false" />
+      <input
+        type="checkbox"
+        name={@name}
+        value="true"
+        class="checkbox checkbox-primary checkbox-sm"
+        checked={@checked}
+      />
+      <span class="text-sm">{@label}</span>
+    </label>
+    """
+  end
+
+  defp plugin_text_input(assigns) do
+    assigns = assign_new(assigns, :hint, fn -> nil end)
+
+    ~H"""
+    <div>
+      <label class="block text-sm text-stone-400 mb-1">{@label}</label>
+      <input
+        type="text"
+        name={@name}
+        value={@value}
+        class="input input-bordered text-sm bg-neutral-800 text-white w-full"
+        placeholder={@placeholder}
+      />
+      <p :if={@hint} class="text-xs text-stone-500 mt-1">{@hint}</p>
+    </div>
+    """
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="plugins-config">
+      <%= if @loading do %>
+        <div class="flex justify-center py-4">
+          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+        </div>
+      <% else %>
+        <%= if @error do %>
+          <div
+            class="border border-red-400 text-red-300 px-4 py-3 rounded mb-4 flex justify-between items-center"
+            phx-click="dismiss_message"
+            phx-target={@myself}
+          >
+            <p>{@error}</p>
+            <span class="cursor-pointer text-sm">&times;</span>
+          </div>
+        <% end %>
+
+        <%= if @success_message do %>
+          <div
+            class="border border-green-400 text-green-300 px-4 py-3 rounded mb-4 flex justify-between items-center"
+            phx-click="dismiss_message"
+            phx-target={@myself}
+          >
+            <p>{@success_message}</p>
+            <span class="cursor-pointer text-sm">&times;</span>
+          </div>
+        <% end %>
+
+        <%= for plugin <- @plugins do %>
+          <div class="mb-6">
+            <div class="flex items-start gap-4 mb-3">
+              <div>
+                <h3 class="text-lg font-semibold">{plugin.display_name}</h3>
+                <p class="text-sm text-stone-400">{plugin.description}</p>
+              </div>
+              <label class="flex items-center gap-2 cursor-pointer shrink-0 ml-auto">
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-primary"
+                  checked={enabled?(@configs, plugin.name)}
+                  phx-click="toggle_plugin"
+                  phx-value-plugin={plugin.name}
+                  phx-target={@myself}
+                />
+                <span class="text-sm">
+                  {if enabled?(@configs, plugin.name), do: "Enabled", else: "Disabled"}
+                </span>
+              </label>
+            </div>
+
+            <%= if enabled?(@configs, plugin.name) and plugin.name == "notifier" do %>
+              <form
+                phx-submit="save_plugin_config"
+                phx-target={@myself}
+                class="border border-stone-700 rounded p-4 space-y-4"
+              >
+                <input type="hidden" name="plugin" value="notifier" />
+
+                <%!-- Discord Setup --%>
+                <div>
+                  <h4 class="text-md font-semibold mb-2 text-stone-300">Discord Setup</h4>
+                  <div class="space-y-3">
+                    <div>
+                      <label class="block text-sm text-stone-400 mb-1">Bot Token *</label>
+                      <div class="flex gap-2">
+                        <input
+                          type={if @show_bot_token, do: "text", else: "password"}
+                          name="bot_token"
+                          value={
+                            config_val(@parsed_configs, "notifier", ["discord", "bot_token"], "")
+                          }
+                          class="input input-bordered text-sm bg-neutral-800 text-white flex-1"
+                          placeholder="Discord bot token"
+                        />
+                        <button
+                          type="button"
+                          phx-click="toggle_bot_token"
+                          phx-target={@myself}
+                          class="btn btn-sm"
+                        >
+                          {if @show_bot_token, do: "Hide", else: "Show"}
+                        </button>
+                      </div>
+                    </div>
+                    <.plugin_text_input
+                      label="Primary Channel ID *"
+                      name="channel_primary"
+                      value={
+                        config_val(
+                          @parsed_configs,
+                          "notifier",
+                          ["discord", "channels", "primary"],
+                          ""
+                        )
+                      }
+                      placeholder="Channel ID for all notifications (required)"
+                    />
+                  </div>
+                </div>
+
+                <%!-- Notification Toggles --%>
+                <div class="grid grid-cols-2 gap-2">
+                  <.plugin_checkbox
+                    name="notifications_enabled"
+                    label="Notifications Enabled"
+                    checked={
+                      config_val(
+                        @parsed_configs,
+                        "notifier",
+                        ["features", "notifications_enabled"],
+                        true
+                      )
+                    }
+                  />
+                  <.plugin_checkbox
+                    name="kill_notifications_enabled"
+                    label="Kill Notifications"
+                    checked={
+                      config_val(
+                        @parsed_configs,
+                        "notifier",
+                        ["features", "kill_notifications_enabled"],
+                        true
+                      )
+                    }
+                  />
+                  <.plugin_checkbox
+                    name="system_notifications_enabled"
+                    label="System Notifications"
+                    checked={
+                      config_val(
+                        @parsed_configs,
+                        "notifier",
+                        ["features", "system_notifications_enabled"],
+                        true
+                      )
+                    }
+                  />
+                  <.plugin_checkbox
+                    name="character_notifications_enabled"
+                    label="Character Notifications"
+                    checked={
+                      config_val(
+                        @parsed_configs,
+                        "notifier",
+                        ["features", "character_notifications_enabled"],
+                        true
+                      )
+                    }
+                  />
+                  <.plugin_checkbox
+                    name="rally_notifications_enabled"
+                    label="Rally Notifications"
+                    checked={
+                      config_val(
+                        @parsed_configs,
+                        "notifier",
+                        ["features", "rally_notifications_enabled"],
+                        true
+                      )
+                    }
+                  />
+                </div>
+
+                <%!-- Advanced Settings Toggle --%>
+                <div
+                  class="flex items-center gap-2 cursor-pointer py-2 text-stone-400 hover:text-stone-300"
+                  phx-click="toggle_advanced"
+                  phx-target={@myself}
+                >
+                  <span class="text-xs">{if @show_advanced, do: "▼", else: "▶"}</span>
+                  <span class="text-sm font-medium">Advanced Settings</span>
+                </div>
+
+                <%= if @show_advanced do %>
+                  <%!-- Channel Overrides --%>
+                  <div>
+                    <h4 class="text-md font-semibold mb-2 text-stone-300">Channel Overrides</h4>
+                    <div class="grid grid-cols-2 gap-3">
+                      <.plugin_text_input
+                        label="System Kill Channel"
+                        name="channel_system_kill"
+                        value={
+                          config_val(
+                            @parsed_configs,
+                            "notifier",
+                            ["discord", "channels", "system_kill"],
+                            ""
+                          )
+                        }
+                        placeholder="Falls back to primary"
+                      />
+                      <.plugin_text_input
+                        label="Character Kill Channel"
+                        name="channel_character_kill"
+                        value={
+                          config_val(
+                            @parsed_configs,
+                            "notifier",
+                            ["discord", "channels", "character_kill"],
+                            ""
+                          )
+                        }
+                        placeholder="Falls back to primary"
+                      />
+                      <.plugin_text_input
+                        label="System Channel"
+                        name="channel_system"
+                        value={
+                          config_val(
+                            @parsed_configs,
+                            "notifier",
+                            ["discord", "channels", "system"],
+                            ""
+                          )
+                        }
+                        placeholder="Falls back to primary"
+                      />
+                      <.plugin_text_input
+                        label="Character Channel"
+                        name="channel_character"
+                        value={
+                          config_val(
+                            @parsed_configs,
+                            "notifier",
+                            ["discord", "channels", "character"],
+                            ""
+                          )
+                        }
+                        placeholder="Falls back to primary"
+                      />
+                      <.plugin_text_input
+                        label="Rally Channel"
+                        name="channel_rally"
+                        value={
+                          config_val(
+                            @parsed_configs,
+                            "notifier",
+                            ["discord", "channels", "rally"],
+                            ""
+                          )
+                        }
+                        placeholder="Falls back to primary"
+                      />
+                      <.plugin_text_input
+                        label="Rally Group IDs"
+                        name="rally_group_ids"
+                        value={
+                          comma_join(
+                            config_val(
+                              @parsed_configs,
+                              "notifier",
+                              ["discord", "rally_group_ids"],
+                              []
+                            )
+                          )
+                        }
+                        placeholder="Comma-separated group IDs"
+                      />
+                    </div>
+                  </div>
+
+                  <%!-- Behavior Toggles --%>
+                  <div>
+                    <h4 class="text-md font-semibold mb-2 text-stone-300">Behavior</h4>
+                    <div class="grid grid-cols-2 gap-2">
+                      <.plugin_checkbox
+                        name="wormhole_only_kill_notifications"
+                        label="Wormhole-only Kills"
+                        checked={
+                          config_val(
+                            @parsed_configs,
+                            "notifier",
+                            ["features", "wormhole_only_kill_notifications"],
+                            false
+                          )
+                        }
+                      />
+                      <.plugin_checkbox
+                        name="track_kspace"
+                        label="Track K-Space"
+                        checked={
+                          config_val(
+                            @parsed_configs,
+                            "notifier",
+                            ["features", "track_kspace"],
+                            true
+                          )
+                        }
+                      />
+                      <.plugin_checkbox
+                        name="priority_systems_only"
+                        label="Priority Systems Only"
+                        checked={
+                          config_val(
+                            @parsed_configs,
+                            "notifier",
+                            ["features", "priority_systems_only"],
+                            false
+                          )
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <%!-- Filtering --%>
+                  <div>
+                    <h4 class="text-md font-semibold mb-2 text-stone-300">Filtering</h4>
+                    <div class="space-y-3">
+                      <.plugin_text_input
+                        label="Corporation Kill Focus"
+                        name="corporation_kill_focus"
+                        value={
+                          comma_join(
+                            config_val(
+                              @parsed_configs,
+                              "notifier",
+                              ["settings", "corporation_kill_focus"],
+                              []
+                            )
+                          )
+                        }
+                        placeholder="Comma-separated corporation EVE IDs"
+                        hint="Kills involving these corps route to character kill channel"
+                      />
+                      <.plugin_text_input
+                        label="Character Exclude List"
+                        name="character_exclude_list"
+                        value={
+                          comma_join(
+                            config_val(
+                              @parsed_configs,
+                              "notifier",
+                              ["settings", "character_exclude_list"],
+                              []
+                            )
+                          )
+                        }
+                        placeholder="Comma-separated character EVE IDs to exclude"
+                      />
+                      <.plugin_text_input
+                        label="System Exclude List"
+                        name="system_exclude_list"
+                        value={
+                          comma_join(
+                            config_val(
+                              @parsed_configs,
+                              "notifier",
+                              ["settings", "system_exclude_list"],
+                              []
+                            )
+                          )
+                        }
+                        placeholder="Comma-separated system IDs to exclude"
+                      />
+                    </div>
+                  </div>
+                <% end %>
+
+                <div class="flex justify-end">
+                  <button
+                    type="submit"
+                    class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-6 rounded"
+                    disabled={@saving}
+                  >
+                    {if @saving, do: "Saving...", else: "Save Configuration"}
+                  </button>
+                </div>
+              </form>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/wanderer_app_web/live/maps/maps_live.ex
+++ b/lib/wanderer_app_web/live/maps/maps_live.ex
@@ -178,6 +178,7 @@ defmodule WandererAppWeb.MapsLive do
           active_settings_tab: "general",
           is_adding_subscription?: false,
           selected_subscription: nil,
+          plugins_available?: WandererApp.Env.plugins_enabled?(),
           options_form: options_form_data |> to_form(),
           layout_options: [
             {"Left To Right", "left_to_right"},

--- a/lib/wanderer_app_web/live/maps/maps_live.html.heex
+++ b/lib/wanderer_app_web/live/maps/maps_live.html.heex
@@ -395,10 +395,10 @@
                   </a>
                 </li>
                 <li
-                  :if={@map_subscriptions_enabled?}
+                  :if={@plugins_available? || @map_subscriptions_enabled?}
                   class={[
                     "p-unselectable-text",
-                    classes("p-tabview-selected p-highlight": @active_settings_tab == "bot")
+                    classes("p-tabview-selected p-highlight": @active_settings_tab == "plugins")
                   ]}
                   role="presentation"
                   data-pc-name=""
@@ -413,10 +413,10 @@
                     aria-disabled="false"
                     data-pc-section="headeraction"
                     phx-click="change_settings_tab"
-                    phx-value-tab="bot"
+                    phx-value-tab="plugins"
                   >
                     <span class="p-tabview-title" data-pc-section="headertitle">
-                      <.icon name="hero-puzzle-piece-solid" class="w-4 h-4" />&nbsp;Bots
+                      <.icon name="hero-puzzle-piece-solid" class="w-4 h-4" />&nbsp;Plugins
                     </span>
                   </a>
                 </li>
@@ -515,37 +515,38 @@
                 </.button>
               </div>
 
-              <div :if={@active_settings_tab == "bot"}>
-                <h3 class="text-lg font-semibold mb-2">Bots Integration</h3>
-                <div class="mb-6 p-4 border rounded-md">
-                  <p class="mb-2">
-                    The bot license allows you to integrate your map with automated tools and bots.
-                    Here's how to use it:
-                  </p>
-                  <ol class="list-decimal pl-5 mb-4 space-y-2">
-                    <li>Create a license key below (requires an active subscription)</li>
-                    <li>Use the license key to authenticate your bot with our API</li>
-                    <%!-- <li>
-                      Make API calls to <code class="bg-gray-800 px-1 py-0.5 rounded">GET /api/license/validate</code>
-                      with the license key as a Bearer token in the Authorization header
-                    </li>
-                    <li>
-                      If valid, you'll receive the map ID which you can use for other API endpoints
-                    </li> --%>
-                  </ol>
-                  <p class="text-sm text-gray-600">
-                    For detailed API documentation, please refer to our <a
-                      href="/license"
-                      class="text-blue-600 hover:underline"
-                    >API documentation</a>.
-                  </p>
-                </div>
+              <div :if={@active_settings_tab == "plugins"}>
+                <%= if @plugins_available? do %>
+                  <.live_component
+                    module={WandererAppWeb.Maps.PluginsComponent}
+                    id="plugins-component"
+                    map_id={@map.id}
+                  />
+                <% else %>
+                  <h3 class="text-lg font-semibold mb-2">Bots Integration</h3>
+                  <div class="mb-6 p-4 border rounded-md">
+                    <p class="mb-2">
+                      The bot license allows you to integrate your map with automated tools and bots.
+                      Here's how to use it:
+                    </p>
+                    <ol class="list-decimal pl-5 mb-4 space-y-2">
+                      <li>Create a license key below (requires an active subscription)</li>
+                      <li>Use the license key to authenticate your bot with our API</li>
+                    </ol>
+                    <p class="text-sm text-gray-600">
+                      For detailed API documentation, please refer to our <a
+                        href="/license"
+                        class="text-blue-600 hover:underline"
+                      >API documentation</a>.
+                    </p>
+                  </div>
 
-                <.live_component
-                  module={WandererAppWeb.Maps.LicenseComponent}
-                  id="license-component"
-                  map_id={@map.id}
-                />
+                  <.live_component
+                    module={WandererAppWeb.Maps.LicenseComponent}
+                    id="license-component"
+                    map_id={@map.id}
+                  />
+                <% end %>
               </div>
 
               <div

--- a/lib/wanderer_app_web/router.ex
+++ b/lib/wanderer_app_web/router.ex
@@ -206,6 +206,11 @@ defmodule WandererAppWeb.Router do
     plug WandererAppWeb.Plugs.CheckWebhooksDisabled
   end
 
+  pipeline :api_plugins do
+    plug WandererAppWeb.Plugs.RequirePluginsEnabled
+    plug WandererAppWeb.Plugs.CheckPluginApiKey
+  end
+
   pipeline :api_acl do
     plug WandererAppWeb.Plugs.CheckAclApiKey
   end
@@ -318,6 +323,13 @@ defmodule WandererAppWeb.Router do
 
     # Webhook control endpoint
     put "/webhooks/toggle", MapAPIController, :toggle_webhooks
+  end
+
+  # Plugin config endpoint (for external bots to discover configured maps)
+  scope "/api/plugins/:plugin_name", WandererAppWeb do
+    pipe_through [:api, :api_plugins]
+
+    get "/config", PluginConfigApiController, :show
   end
 
   #

--- a/priv/repo/migrations/20260215120000_add_map_plugin_configs.exs
+++ b/priv/repo/migrations/20260215120000_add_map_plugin_configs.exs
@@ -1,0 +1,49 @@
+defmodule WandererApp.Repo.Migrations.AddMapPluginConfigs do
+  @moduledoc """
+  Creates the map_plugin_configs_v1 table for storing per-map plugin configuration.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    create table(:map_plugin_configs_v1, primary_key: false) do
+      add :id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true
+
+      add :map_id,
+          references(:maps_v1,
+            column: :id,
+            name: "map_plugin_configs_v1_map_id_fkey",
+            type: :uuid,
+            prefix: "public"
+          ),
+          null: false
+
+      add :plugin_name, :text, null: false
+      add :enabled, :boolean, null: false, default: false
+      add :encrypted_config, :binary
+      add :config_version, :bigint, null: false, default: 1
+
+      add :inserted_at, :utc_datetime_usec,
+        null: false,
+        default: fragment("(now() AT TIME ZONE 'utc')")
+
+      add :updated_at, :utc_datetime_usec,
+        null: false,
+        default: fragment("(now() AT TIME ZONE 'utc')")
+    end
+
+    create unique_index(:map_plugin_configs_v1, [:map_id, :plugin_name],
+             name: "map_plugin_configs_v1_unique_map_plugin_index"
+           )
+  end
+
+  def down do
+    drop_if_exists unique_index(:map_plugin_configs_v1, [:map_id, :plugin_name],
+                     name: "map_plugin_configs_v1_unique_map_plugin_index"
+                   )
+
+    drop constraint(:map_plugin_configs_v1, "map_plugin_configs_v1_map_id_fkey")
+
+    drop table(:map_plugin_configs_v1)
+  end
+end

--- a/priv/repo/migrations/20260215130000_add_plugin_config_cascade_delete.exs
+++ b/priv/repo/migrations/20260215130000_add_plugin_config_cascade_delete.exs
@@ -1,0 +1,35 @@
+defmodule WandererApp.Repo.Migrations.AddPluginConfigCascadeDelete do
+  @moduledoc """
+  Adds cascade delete to map_plugin_configs_v1 foreign key so plugin configs
+  are automatically cleaned up when a map is hard-deleted.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:map_plugin_configs_v1, "map_plugin_configs_v1_map_id_fkey")
+
+    alter table(:map_plugin_configs_v1) do
+      modify :map_id,
+             references(:maps_v1,
+               column: :id,
+               name: "map_plugin_configs_v1_map_id_fkey",
+               type: :uuid,
+               on_delete: :delete_all
+             )
+    end
+  end
+
+  def down do
+    drop constraint(:map_plugin_configs_v1, "map_plugin_configs_v1_map_id_fkey")
+
+    alter table(:map_plugin_configs_v1) do
+      modify :map_id,
+             references(:maps_v1,
+               column: :id,
+               name: "map_plugin_configs_v1_map_id_fkey",
+               type: :uuid
+             )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a plugin system for managing per-map plugin configuration (starting with a Discord Notifier plugin)
- New `map_plugin_configs_v1` table with AshCloak encryption for sensitive config fields (e.g. bot tokens)
- Plugin registry defines available plugins in code; per-map configs stored in DB
- LiveView component for enabling/disabling plugins and editing config per map (under Settings > Plugins tab)
- Authenticated API endpoint (`GET /api/plugins/:plugin_name/config`) for external bots to discover enabled maps and retrieve config
- Feature-gated behind `WANDERER_PLUGINS_ENABLED` env var; falls back to existing Bots/License UI when disabled

### New files
- `MapPluginConfig` Ash resource + migrations (with cascade delete on map removal)
- `PluginRegistry` — fixed catalog of known plugins, config validation/normalization, shared JSON parsing
- `Plugins` — server-wide plugin config helpers (API key lookup)
- `PluginConfigApiController` — external bot config discovery endpoint
- `CheckPluginApiKey` / `RequirePluginsEnabled` plugs — auth and feature gate
- `PluginsComponent` — LiveView form for plugin config management

## Test plan
- [ ] Set `WANDERER_PLUGINS_ENABLED=true` and `WANDERER_PLUGIN_NOTIFIER_API_KEY=<key>`, run migrations
- [ ] Open map settings, verify Plugins tab appears with Discord Notifier toggle
- [ ] Enable plugin, fill in bot token + primary channel, save — verify config persists across page reload
- [ ] Toggle advanced settings, fill channel overrides and filtering, save
- [ ] Enter invalid values in integer fields (e.g. "abc" in Corporation Kill Focus) — verify validation error surfaces
- [ ] Disable plugin, verify toggle state persists
- [ ] `curl -H "Authorization: Bearer <key>" /api/plugins/notifier/config` — verify enabled maps returned with config
- [ ] With plugins disabled (`WANDERER_PLUGINS_ENABLED=false`), verify Plugins tab shows legacy Bots UI
- [ ] Verify plugin configs are deleted when a map is hard-deleted (cascade)

![pluginoff](https://github.com/user-attachments/assets/9db59d8e-f338-4a7b-a9e2-614b412155a7)
![pluginon](https://github.com/user-attachments/assets/f421a02f-1e7f-4004-a225-8c754bfc6186)
![advanced](https://github.com/user-attachments/assets/cc7e73ea-3107-4589-aad5-512f8107a266)
