### PR TITLE
fix: C729 reversal - Allow multiple destinations for Wormholes

### DIFF
--- a/assets/js/hooks/Mapper/components/map/constants.ts
+++ b/assets/js/hooks/Mapper/components/map/constants.ts
@@ -314,6 +314,13 @@ export const WORMHOLES_ADDITIONAL_INFO_RAW: WormholesAdditionalInfoType[] = [
     title: 'Reverse',
     shortTitle: 'K162',
   },
+  {
+    id: 'c729',
+    shortName: 'C729',
+    wormholeClassID: 10102,
+    title: 'Static',
+    shortTitle: 'C729',
+  },
 ];
 
 export const WORMHOLES_ADDITIONAL_INFO: Record<string, WormholesAdditionalInfoType> =

--- a/assets/js/hooks/Mapper/components/map/helpers/wormholeClassFillVars.ts
+++ b/assets/js/hooks/Mapper/components/map/helpers/wormholeClassFillVars.ts
@@ -1,5 +1,5 @@
 import { WORMHOLE_CLASS_STYLES, WORMHOLES_ADDITIONAL_INFO } from '@/hooks/Mapper/components/map/constants';
-import { K162_TYPES_MAP } from '@/hooks/Mapper/constants';
+import { MULTI_DEST_WHS, ALL_DEST_TYPES_MAP } from '@/hooks/Mapper/constants';
 import { parseSignatureCustomInfo } from '@/hooks/Mapper/helpers/parseSignatureCustomInfo';
 import { WormholeDataRaw } from '@/hooks/Mapper/types/wormholes';
 import { SystemSignature } from '@/hooks/Mapper/types/signatures';
@@ -33,14 +33,14 @@ export function resolveSignatureFillVar(
 ): string {
   const customInfo = parseSignatureCustomInfo(signature.custom_info);
 
-  // K162 override: use the k162Type to look up the real destination class
-  if (signature.type === 'K162' && customInfo.k162Type) {
-    const k162Option = K162_TYPES_MAP[customInfo.k162Type];
-    if (k162Option) {
-      const k162Data = wormholesData[k162Option.whClassName];
-      const k162Class = k162Data ? WORMHOLES_ADDITIONAL_INFO[k162Data.dest] : null;
-      if (k162Class) {
-        const className = WORMHOLE_CLASS_STYLES[k162Class.wormholeClassID];
+  // Wormholes with multiple exit classes (K162, C729, ...) override: use the destType to look up the real destination class
+  if (MULTI_DEST_WHS.includes(signature.type) && customInfo.destType) {
+    const destTypeOption = ALL_DEST_TYPES_MAP[customInfo.destType];
+    if (destTypeOption) {
+      const whData = wormholesData[destTypeOption.whClassName];
+      const whClass = whData?.dest?.length === 1 ? WORMHOLES_ADDITIONAL_INFO[whData.dest[0]] : null;
+      if (whClass) {
+        const className = WORMHOLE_CLASS_STYLES[whClass.wormholeClassID];
         if (className && CLASS_NAME_TO_CSS_VAR[className]) {
           return CLASS_NAME_TO_CSS_VAR[className];
         }
@@ -53,7 +53,7 @@ export function resolveSignatureFillVar(
   const whData = wormholesData[signature.type];
   if (!whData) return DEFAULT_FILL;
 
-  const whClass = WORMHOLES_ADDITIONAL_INFO[whData.dest];
+  const whClass = whData?.dest?.length == 1 ? WORMHOLES_ADDITIONAL_INFO[whData.dest[0]] : null;
   if (!whClass) return DEFAULT_FILL;
 
   const className = WORMHOLE_CLASS_STYLES[whClass.wormholeClassID];

--- a/assets/js/hooks/Mapper/components/mapInterface/components/SystemLinkSignatureDialog/SystemLinkSignatureDialog.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/components/SystemLinkSignatureDialog/SystemLinkSignatureDialog.tsx
@@ -8,7 +8,7 @@ import {
     WORMHOLES_ADDITIONAL_INFO_BY_SHORT_NAME,
 } from '@/hooks/Mapper/components/map/constants.ts';
 import { SystemSignaturesContent } from '@/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/SystemSignaturesContent';
-import { K162_TYPES_MAP } from '@/hooks/Mapper/constants.ts';
+import { MULTI_DEST_WHS, ALL_DEST_TYPES_MAP, DEST_TYPES_MAP_MAP } from '@/hooks/Mapper/constants.ts';
 import { SETTINGS_KEYS, SignatureSettingsType } from '@/hooks/Mapper/constants/signatures';
 import { parseSignatureCustomInfo } from '@/hooks/Mapper/helpers/parseSignatureCustomInfo';
 import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
@@ -16,7 +16,7 @@ import { CommandLinkSignatureToSystem, SignatureGroup, SystemSignature } from '@
 import { OutCommand } from '@/hooks/Mapper/types/mapHandlers.ts';
 import { useSystemSignaturesData } from '../../widgets/SystemSignatures/hooks/useSystemSignaturesData';
 
-const K162_SIGNATURE_TYPE = WORMHOLES_ADDITIONAL_INFO_BY_SHORT_NAME['K162'].shortName;
+const MULTI_DEST_TYPES = MULTI_DEST_WHS.map((type: string) => WORMHOLES_ADDITIONAL_INFO_BY_SHORT_NAME[type].shortName);
 
 interface SystemLinkSignatureDialogProps {
   data: CommandLinkSignatureToSystem;
@@ -29,9 +29,9 @@ export const LINK_SIGNTATURE_SETTINGS: SignatureSettingsType = {
   [SETTINGS_KEYS.SHOW_DESCRIPTION_COLUMN]: true,
 };
 
-// Extend the SignatureCustomInfo type to include k162Type
+// Extend the SignatureCustomInfo type to include destType
 interface ExtendedSignatureCustomInfo {
-  k162Type?: string;
+  destType?: string;
   isEOL?: boolean;
   [key: string]: unknown;
 }
@@ -80,23 +80,22 @@ export const SystemLinkSignatureDialog = ({ data, setVisible }: SystemLinkSignat
         return true;
       }
 
-      if (signature.type === K162_SIGNATURE_TYPE) {
-        // Parse the custom info to see if the user has specified what class this K162 leads to
+      if (MULTI_DEST_TYPES.includes(signature.type)) {
+        // Parse the custom info to see if the user has specified what class
+        // this wormhole leads to
         const customInfo = parseSignatureCustomInfo(signature.custom_info) as ExtendedSignatureCustomInfo;
 
-        // If the user has specified a k162Type for this K162
-        if (customInfo.k162Type) {
-          // Get the K162 type information
-          const k162TypeInfo = K162_TYPES_MAP[customInfo.k162Type];
+        // If the user has specified a destType for this wormhole
+        if (customInfo.destType) {
+          // Get the destination type information
+          const destinationInfo = DEST_TYPES_MAP_MAP[signature.type][customInfo.destType];
 
-          if (k162TypeInfo) {
-            // Check if the k162Type matches our target system class
-            return k162TypeInfo.value.includes(targetSystemClassGroup);
+          if (destinationInfo) {
+            // Check if the destType matches our target system class
+            const isDestMatch = destinationInfo.value.includes(targetSystemClassGroup);
+            return isDestMatch;
           }
         }
-
-        // If no k162Type is specified or we couldn't find type info, allow it
-        return true;
       }
 
       // Find the wormhole data for this signature type
@@ -105,11 +104,12 @@ export const SystemLinkSignatureDialog = ({ data, setVisible }: SystemLinkSignat
         return true; // If we don't know the destination, don't filter it out
       }
 
-      // Get the destination system class from the wormhole data
+      // Get the destination system classes from the wormhole data
       const destinationClass = wormholeData.dest;
 
-      // Check if the destination class matches the target system class
-      const isMatch = destinationClass === targetSystemClassGroup;
+      // If destinationClass is null, then it's K162 and allow, else
+      // check if any of the destination classes matches the target system class
+      const isMatch = destinationClass == null || destinationClass.includes(targetSystemClassGroup);
       return isMatch;
     },
     [targetSystemClassGroup, wormholes],

--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/renders/renderInfoColumn.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/renders/renderInfoColumn.tsx
@@ -2,10 +2,10 @@ import { SystemViewStandalone, TooltipPosition, WHClassView } from '@/hooks/Mapp
 import { MassState, SignatureGroup, SystemSignature, TimeStatus } from '@/hooks/Mapper/types';
 import { PrimeIcons } from 'primereact/api';
 
-import { renderK162Type } from '@/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureK162TypeSelect';
+import { renderDestinationType } from '@/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureDestinationTypeSelect';
 import { WdTooltipWrapper } from '@/hooks/Mapper/components/ui-kit/WdTooltipWrapper';
 
-import { K162_TYPES_MAP } from '@/hooks/Mapper/constants.ts';
+import { MULTI_DEST_WHS, ALL_DEST_TYPES_MAP } from '@/hooks/Mapper/constants.ts';
 import { parseSignatureCustomInfo } from '@/hooks/Mapper/helpers/parseSignatureCustomInfo.ts';
 import clsx from 'clsx';
 import { renderName } from './renderName.tsx';
@@ -14,7 +14,7 @@ export const renderInfoColumn = (row: SystemSignature) => {
   if (!row.group || row.group === SignatureGroup.Wormhole) {
     const customInfo = parseSignatureCustomInfo(row.custom_info);
 
-    const k162TypeOption = customInfo.k162Type ? K162_TYPES_MAP[customInfo.k162Type] : null;
+    const destTypeOption = customInfo.destType ? ALL_DEST_TYPES_MAP[customInfo.destType] : null;
 
     return (
       <div className="flex justify-start items-center gap-[4px]">
@@ -46,14 +46,17 @@ export const renderInfoColumn = (row: SystemSignature) => {
           <WHClassView
             className="text-[11px]"
             classNameWh="!text-[11px] !font-bold"
-            hideWhClass={!!row.linked_system}
+            hideWhClass={!!destTypeOption || !!row.linked_system}
             whClassName={row.type}
             noOffset
             useShortTitle
           />
         )}
 
-        {!row.linked_system && row.type === 'K162' && k162TypeOption && renderK162Type(k162TypeOption)}
+        {!row.linked_system &&
+          MULTI_DEST_WHS.includes(row.type) &&
+          destTypeOption &&
+          renderDestinationType(destTypeOption)}
 
         {row.linked_system && (
           <>

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/SignatureSettings.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/SignatureSettings.tsx
@@ -13,7 +13,7 @@ import { Controller, FormProvider, useForm } from 'react-hook-form';
 
 type SystemSignaturePrepared = Omit<SystemSignature, 'linked_system'> & {
   linked_system: string;
-  k162Type: string;
+  destType: string;
   time_status: TimeStatus;
   mass_status: MassState;
 };
@@ -47,7 +47,7 @@ export const SignatureSettings = ({ systemId, show, onHide, signatureData }: Map
           out = {
             ...out,
             custom_info: JSON.stringify({
-              k162Type: values.k162Type,
+              destType: values.destType,
               time_status: values.time_status,
               mass_status: values.mass_status,
             }),
@@ -142,19 +142,19 @@ export const SignatureSettings = ({ systemId, show, onHide, signatureData }: Map
 
     const { linked_system, custom_info, ...rest } = signatureData;
 
-    let k162Type = null;
+    let destType = null;
     let time_status = TimeStatus._24h;
     let mass_status = MassState.normal;
     if (custom_info) {
       const customInfo = JSON.parse(custom_info);
-      k162Type = customInfo.k162Type;
+      destType = customInfo.destType;
       time_status = customInfo.time_status;
       mass_status = customInfo.mass_status ?? MassState.normal;
     }
 
     signatureForm.reset({
       linked_system: linked_system?.solar_system_id.toString() ?? undefined,
-      k162Type: k162Type,
+      destType: destType,
       time_status: time_status,
       mass_status: mass_status,
       ...rest,

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureDestinationTypeSelect/SignatureDestinationTypeSelect.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureDestinationTypeSelect/SignatureDestinationTypeSelect.tsx
@@ -3,20 +3,25 @@ import clsx from 'clsx';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useMemo } from 'react';
 import { SystemSignature } from '@/hooks/Mapper/types';
-import { K162_TYPES } from '@/hooks/Mapper/constants.ts';
-import { renderK162Type } from '.';
+import { renderDestinationType } from '.';
+import { DEST_TYPES_MAP } from '@/hooks/Mapper/constants';
 
-export interface SignatureK162TypeSelectProps {
+export interface SignatureDestinationTypeSelectProps {
   name: string;
+  type: string;
   defaultValue?: string;
 }
 
-export const SignatureK162TypeSelect = ({ name, defaultValue = '' }: SignatureK162TypeSelectProps) => {
+export const SignatureDestinationTypeSelect = ({
+  name,
+  type: whType,
+  defaultValue = '',
+}: SignatureDestinationTypeSelectProps) => {
   const { control } = useFormContext<SystemSignature>();
 
   const options = useMemo(() => {
-    return [{ value: null }, ...K162_TYPES];
-  }, []);
+    return [{ value: null }, ...DEST_TYPES_MAP[whType]];
+  }, [whType]);
 
   return (
     <Controller
@@ -31,11 +36,11 @@ export const SignatureK162TypeSelect = ({ name, defaultValue = '' }: SignatureK1
             onChange={field.onChange}
             options={options}
             optionValue="value"
-            placeholder="Select K162 type"
+            placeholder="Select destination"
             className={clsx('w-full')}
             scrollHeight="240px"
-            itemTemplate={renderK162Type}
-            valueTemplate={renderK162Type}
+            itemTemplate={renderDestinationType}
+            valueTemplate={renderDestinationType}
           />
         );
       }}

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureDestinationTypeSelect/index.ts
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureDestinationTypeSelect/index.ts
@@ -1,0 +1,2 @@
+export * from './SignatureDestinationTypeSelect.tsx';
+export * from './renderDestinationType.tsx';

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureDestinationTypeSelect/renderDestinationType.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureDestinationTypeSelect/renderDestinationType.tsx
@@ -1,9 +1,9 @@
 import { WHClassView } from '@/hooks/Mapper/components/ui-kit';
-import { K162Type } from '@/hooks/Mapper/constants.ts';
+import { DestinationType } from '@/hooks/Mapper/constants.ts';
 
 const renderNoValue = () => <div className="flex gap-2 items-center">-Unknown-</div>;
 
-export const renderK162Type = (option: K162Type) => {
+export const renderDestinationType = (option: DestinationType) => {
   if (!option) {
     return renderNoValue();
   }

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureGroupContentWormholes.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureGroupContentWormholes.tsx
@@ -1,11 +1,12 @@
 import { useFormContext } from 'react-hook-form';
 import { SystemSignature } from '@/hooks/Mapper/types';
 import { SignatureWormholeTypeSelect } from '@/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureWormholeTypeSelect';
-import { SignatureK162TypeSelect } from '@/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureK162TypeSelect';
+import { SignatureDestinationTypeSelect } from '@/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureDestinationTypeSelect';
 import { SignatureLeadsToSelect } from '@/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureLeadsToSelect';
 import { SignatureLifetimeSelect } from '@/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureLifetimeSelect.tsx';
 import { SignatureTempName } from '@/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureTempName.tsx';
 import { SignatureMassStatusSelect } from '@/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureMassStatusSelect.tsx';
+import { MULTI_DEST_WHS } from '@/hooks/Mapper/constants';
 
 export const SignatureGroupContentWormholes = () => {
   const { watch } = useFormContext<SystemSignature>();
@@ -18,10 +19,10 @@ export const SignatureGroupContentWormholes = () => {
         <SignatureWormholeTypeSelect name="type" />
       </label>
 
-      {type === 'K162' && (
+      {MULTI_DEST_WHS.includes(type) && (
         <label className="grid grid-cols-[100px_250px_1fr] gap-2 items-center text-[14px]">
-          <span>K162 Type:</span>
-          <SignatureK162TypeSelect name="k162Type" />
+          <span>Destination Class:</span>
+          <SignatureDestinationTypeSelect name="destType" type={type} />
         </label>
       )}
 

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureK162TypeSelect/index.ts
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureK162TypeSelect/index.ts
@@ -1,2 +1,0 @@
-export * from './SignatureK162TypeSelect.tsx';
-export * from './renderK162Type.tsx';

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureLeadsToSelect/SignatureLeadsToSelect.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureLeadsToSelect/SignatureLeadsToSelect.tsx
@@ -77,7 +77,7 @@ export const SignatureLeadsToSelect = ({ name, defaultValue = '' }: SignatureLea
           }
 
           const { id: whType } = WORMHOLES_ADDITIONAL_INFO_BY_CLASS_ID[systemStatic.system_class];
-          return whInfo.dest === whType;
+          return whInfo.dest.includes(whType);
         })
         .map(x => ({ value: x })),
     ];

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/index.ts
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/index.ts
@@ -1,5 +1,5 @@
 export * from './SignatureGroupSelect';
 export * from './SignatureGroupContent';
-export * from './SignatureK162TypeSelect';
+export * from './SignatureDestinationTypeSelect';
 export * from './SignatureLifetimeSelect';
 export * from './SignatureMassStatusSelect';

--- a/assets/js/hooks/Mapper/components/ui-kit/WHClassView/WHClassView.tsx
+++ b/assets/js/hooks/Mapper/components/ui-kit/WHClassView/WHClassView.tsx
@@ -42,8 +42,10 @@ export const WHClassView = ({
   } = useMapRootState();
 
   const whData = useMemo(() => wormholesData[whClassName], [whClassName, wormholesData]);
-  const whClass = useMemo(() => WORMHOLES_ADDITIONAL_INFO[whData.dest], [whData.dest]);
-  const whClassStyle = WORMHOLE_CLASS_STYLES[whClass?.wormholeClassID] ?? '';
+  const whClass = useMemo(() => {
+    return whData?.dest?.length === 1 ? WORMHOLES_ADDITIONAL_INFO[whData.dest[0]] : null;
+  }, [whData.dest]);
+  const whClassStyle = whClass?.wormholeClassID ? WORMHOLE_CLASS_STYLES[whClass.wormholeClassID] : '';
 
   const content = (
     <div

--- a/assets/js/hooks/Mapper/constants.ts
+++ b/assets/js/hooks/Mapper/constants.ts
@@ -66,13 +66,15 @@ export const REGIONS_MAP: Record<number, Spaces> = {
   [Regions.Pochven]: Spaces.Pochven,
 };
 
-export type K162Type = {
+export type DestinationType = {
   label: string;
   value: string;
   whClassName: string;
 };
 
-export const K162_TYPES: K162Type[] = [
+export const MULTI_DEST_WHS: string[] = ['K162', 'C729'];
+
+export const ALL_DEST_TYPES: DestinationType[] = [
   {
     label: 'Hi-Sec',
     value: 'hs',
@@ -145,10 +147,29 @@ export const K162_TYPES: K162Type[] = [
   },
 ];
 
-export const K162_TYPES_MAP: { [key: string]: K162Type } = K162_TYPES.reduce(
+export const ALL_DEST_TYPES_MAP: { [key: string]: DestinationType } = ALL_DEST_TYPES.reduce(
   (acc, x) => ({ ...acc, [x.value]: x }),
   {},
 );
+
+export const C729_DEST_TYPES: DestinationType[] = ALL_DEST_TYPES.filter(destType =>
+  ['hs', 'ls', 'ns', 'pochven'].includes(destType.value),
+);
+
+export const C729_DEST_TYPES_MAP: { [key: string]: DestinationType } = C729_DEST_TYPES.reduce(
+  (acc, x) => ({ ...acc, [x.value]: x }),
+  {},
+);
+
+export const DEST_TYPES_MAP: { [key: string]: DestinationType[] } = {
+  K162: ALL_DEST_TYPES,
+  C729: C729_DEST_TYPES,
+};
+
+export const DEST_TYPES_MAP_MAP: { [key: string]: { [key: string]: DestinationType } } = {
+  K162: ALL_DEST_TYPES_MAP,
+  C729: C729_DEST_TYPES_MAP,
+};
 
 export const MINIMAP_PLACEMENT_MAP = {
   [PingsPlacement.rightTop]: 'top-right',

--- a/assets/js/hooks/Mapper/types/signatures.ts
+++ b/assets/js/hooks/Mapper/types/signatures.ts
@@ -28,7 +28,7 @@ export type GroupType = {
 };
 
 export type SignatureCustomInfo = {
-  k162Type?: string;
+  destType?: string;
   time_status?: number;
   isCrit?: boolean;
   mass_status?: number;

--- a/assets/js/hooks/Mapper/types/wormholes.ts
+++ b/assets/js/hooks/Mapper/types/wormholes.ts
@@ -5,7 +5,7 @@ export enum Respawn {
 }
 
 export type WormholeDataRaw = {
-  dest: string;
+  dest: string[];
   id: number;
   lifetime: string;
   mass_regen: number;

--- a/lib/wanderer_app/eve_data_service.ex
+++ b/lib/wanderer_app/eve_data_service.ex
@@ -114,6 +114,7 @@ defmodule WandererApp.EveDataService do
       %{
         solar_system_id: row["solarSystemID"],
         solar_system_name: row["solarSystemName"],
+        statics: row["statics"],
         effect_name: row["effectName"],
         effect_power: row["effectPower"],
         invasion_status: row["invasionStatus"]
@@ -403,6 +404,7 @@ defmodule WandererApp.EveDataService do
         %{
           default_data
           | triglavian_invasion_status: triglavian_data.invasion_status,
+            statics: triglavian_data.statics,
             effect_name: triglavian_data.effect_name,
             effect_power: triglavian_data.effect_power
         }

--- a/priv/repo/data/triglavianSystems.json
+++ b/priv/repo/data/triglavianSystems.json
@@ -2,6 +2,9 @@
    {
       "solarSystemName": "Ignebaener",
       "solarSystemID": 30005005,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -9,6 +12,9 @@
    {
       "solarSystemName": "Kino",
       "solarSystemID": 30001372,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -16,6 +22,9 @@
    {
       "solarSystemName": "Komo",
       "solarSystemID": 30031392,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -23,6 +32,9 @@
    {
       "solarSystemName": "Konola",
       "solarSystemID": 30002737,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -30,6 +42,9 @@
    {
       "solarSystemName": "Krirald",
       "solarSystemID": 30002079,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -37,6 +52,9 @@
    {
       "solarSystemName": "Nalvula",
       "solarSystemID": 30001445,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -44,6 +62,9 @@
    {
       "solarSystemName": "Otanuomi",
       "solarSystemID": 30000192,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -51,6 +72,9 @@
    {
       "solarSystemName": "Otela",
       "solarSystemID": 30000157,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -58,6 +82,9 @@
    {
       "solarSystemName": "Sakenta",
       "solarSystemID": 30010141,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -65,6 +92,9 @@
    {
       "solarSystemName": "Ahtila",
       "solarSystemID": 30045328,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -72,6 +102,9 @@
    {
       "solarSystemName": "Harva",
       "solarSystemID": 30002225,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -79,6 +112,9 @@
    {
       "solarSystemName": "Kuharah",
       "solarSystemID": 30000021,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -86,6 +122,9 @@
    {
       "solarSystemName": "Nani",
       "solarSystemID": 30001413,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -93,6 +132,9 @@
    {
       "solarSystemName": "Niarja",
       "solarSystemID": 30003504,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -100,6 +142,9 @@
    {
       "solarSystemName": "Raravoss",
       "solarSystemID": 30003495,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -107,6 +152,9 @@
    {
       "solarSystemName": "Skarkon",
       "solarSystemID": 30002411,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -114,6 +162,9 @@
    {
       "solarSystemName": "Tunudan",
       "solarSystemID": 30002770,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -121,6 +172,9 @@
    {
       "solarSystemName": "Urhinichi",
       "solarSystemID": 30040141,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -128,6 +182,9 @@
    {
       "solarSystemName": "Ala",
       "solarSystemID": 30002652,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -135,6 +192,9 @@
    {
       "solarSystemName": "Kaunokka",
       "solarSystemID": 30002797,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -142,6 +202,9 @@
    {
       "solarSystemName": "Wirashoda",
       "solarSystemID": 30000206,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -149,6 +212,9 @@
    {
       "solarSystemName": "Archee",
       "solarSystemID": 30002702,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -156,6 +222,9 @@
    {
       "solarSystemName": "Angymonne",
       "solarSystemID": 30003046,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -163,6 +232,9 @@
    {
       "solarSystemName": "Senda",
       "solarSystemID": 30020141,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -170,6 +242,9 @@
    {
       "solarSystemName": "Ichoriya",
       "solarSystemID": 30045329,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"
@@ -177,6 +252,9 @@
    {
       "solarSystemName": "Arvasaras",
       "solarSystemID": 30001381,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"

--- a/priv/repo/data/wormholes.json
+++ b/priv/repo/data/wormholes.json
@@ -1,7 +1,7 @@
 [
   {
     "mass_regen": "3000000000",
-    "dest": "c13",
+    "dest": ["c13"],
     "src": ["c1", "c2", "c3", "c4", "c5", "c6", "thera", "c13", "ns"],
     "static": false,
     "max_mass_per_jump": 5000000,
@@ -12,7 +12,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["c2"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -23,7 +23,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "hs",
+    "dest": ["hs"],
     "src": ["hs"],
     "static": false,
     "max_mass_per_jump": 1000000000,
@@ -34,7 +34,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c6",
+    "dest": ["c6"],
     "src": ["c3", "thera"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -45,7 +45,7 @@
   },
   {
     "mass_regen": 500000000,
-    "dest": "c6",
+    "dest": ["c6"],
     "src": ["hs"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -56,7 +56,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "hs",
+    "dest": ["hs"],
     "src": ["c2"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -67,7 +67,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "hs",
+    "dest": ["hs"],
     "src": ["ls", "ns"],
     "static": false,
     "max_mass_per_jump": 1000000000,
@@ -78,7 +78,7 @@
   },
   {
     "mass_regen": 500000000,
-    "dest": "hs",
+    "dest": ["hs"],
     "src": ["c6"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -89,7 +89,7 @@
   },
   {
     "mass_regen": null,
-    "dest": "barbican",
+    "dest": ["barbican"],
     "src": ["hs", "ls", "ns", "jove"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -100,7 +100,7 @@
   },
   {
     "mass_regen": "3000000000",
-    "dest": "c5",
+    "dest": ["c5"],
     "src": ["c1", "c2", "c3", "c4", "c5", "c6", "thera", "c13"],
     "static": false,
     "max_mass_per_jump": 5000000,
@@ -111,7 +111,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c2",
+    "dest": ["c2"],
     "src": ["c1"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -122,7 +122,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["c5", "c6"],
     "static": false,
     "max_mass_per_jump": 1350000000,
@@ -133,7 +133,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c3",
+    "dest": ["c3"],
     "src": ["c4"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -144,7 +144,7 @@
   },
   {
     "mass_regen": 500000000,
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["c6"],
     "static": false,
     "max_mass_per_jump": 1350000000,
@@ -155,7 +155,7 @@
   },
   {
     "mass_regen": 500000000,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["c6"],
     "static": false,
     "max_mass_per_jump": 1000000000,
@@ -166,7 +166,7 @@
   },
   {
     "mass_regen": null,
-    "dest": "conflux",
+    "dest": ["conflux"],
     "src": ["hs", "ls", "ns", "jove"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -177,7 +177,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": null,
+    "dest": ["hs", "ls", "ns", "pochven"],
     "src": ["pochven"],
     "static": true,
     "max_mass_per_jump": 1000000000,
@@ -188,7 +188,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c2",
+    "dest": ["c2"],
     "src": ["c5"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -199,7 +199,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c2",
+    "dest": ["c2"],
     "src": ["c2", "drifter"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -210,7 +210,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "hs",
+    "dest": ["hs"],
     "src": ["c5", "c6"],
     "static": false,
     "max_mass_per_jump": 1000000000,
@@ -221,7 +221,7 @@
   },
   {
     "mass_regen": 500000000,
-    "dest": "hs",
+    "dest": ["hs"],
     "src": ["c3", "c4-shattered"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -232,7 +232,7 @@
   },
   {
     "mass_regen": "3000000000",
-    "dest": "c1",
+    "dest": ["c1"],
     "src": ["c1", "c2", "c3", "c4", "c5", "c6", "thera", "c13"],
     "static": false,
     "max_mass_per_jump": 5000000,
@@ -243,7 +243,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c4",
+    "dest": ["c4"],
     "src": ["c5"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -254,7 +254,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["c2"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -265,7 +265,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["thera"],
     "static": true,
     "max_mass_per_jump": 1000000000,
@@ -276,7 +276,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "thera",
+    "dest": ["thera"],
     "src": ["c2", "c3", "c4", "c5", "c6"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -287,7 +287,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "pochven",
+    "dest": ["pochven"],
     "src": ["c2", "c3", "c4", "c5", "c6"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -298,7 +298,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "thera",
+    "dest": ["thera"],
     "src": ["c1"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -309,7 +309,7 @@
   },
   {
     "mass_regen": "3000000000",
-    "dest": "c6",
+    "dest": ["c6"],
     "src": ["c1", "c2", "c3", "c4", "c5", "c6", "thera", "c13"],
     "static": false,
     "max_mass_per_jump": 5000000,
@@ -320,7 +320,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c2",
+    "dest": ["c2"],
     "src": ["c6"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -331,7 +331,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c1",
+    "dest": ["c1"],
     "src": ["c1"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -342,7 +342,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c5",
+    "dest": ["c5"],
     "src": ["c5"],
     "static": true,
     "max_mass_per_jump": 2000000000,
@@ -353,7 +353,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c5",
+    "dest": ["c5"],
     "src": ["c4"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -364,7 +364,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c2",
+    "dest": ["c2"],
     "src": ["c3", "thera"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -375,7 +375,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["c1"],
     "static": true,
     "max_mass_per_jump": 62000000,
@@ -386,7 +386,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["c1", "c2", "c3", "c4", "thera"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -397,7 +397,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["c4"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -408,7 +408,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["c3", "c4-shattered", "c5-shattered", "c6-shattered"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -419,7 +419,7 @@
   },
   {
     "mass_regen": "3000000000",
-    "dest": "c2",
+    "dest": ["c2"],
     "src": ["c1", "c2", "c3", "c4", "c5", "c6", "thera", "c13"],
     "static": false,
     "max_mass_per_jump": 5000000,
@@ -430,7 +430,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "thera",
+    "dest": ["thera"],
     "src": ["ns"],
     "static": false,
     "max_mass_per_jump": 1000000000,
@@ -441,7 +441,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c3",
+    "dest": ["c3"],
     "src": ["c6"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -452,7 +452,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c5",
+    "dest": ["c5"],
     "src": ["c1", "ns"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -463,7 +463,7 @@
   },
   {
     "mass_regen": "3000000000",
-    "dest": "c4",
+    "dest": ["c4"],
     "src": ["c1", "c2", "c3", "c4", "c5", "c6", "thera", "c13"],
     "static": false,
     "max_mass_per_jump": 5000000,
@@ -474,7 +474,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "thera",
+    "dest": ["thera"],
     "src": ["ls"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -485,7 +485,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c3",
+    "dest": ["c3"],
     "src": ["c5"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -496,7 +496,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c5",
+    "dest": ["c5"],
     "src": ["hs"],
     "static": false,
     "max_mass_per_jump": 1000000000,
@@ -507,7 +507,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c4",
+    "dest": ["c4"],
     "src": ["c1"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -518,7 +518,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c5",
+    "dest": ["c5"],
     "src": ["c2", "drifter"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -529,7 +529,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "hs",
+    "dest": ["hs"],
     "src": ["c1"],
     "static": true,
     "max_mass_per_jump": 62000000,
@@ -540,7 +540,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["c4"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -551,7 +551,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c5",
+    "dest": ["c5"],
     "src": ["ls", "ns"],
     "static": false,
     "max_mass_per_jump": 2000000000,
@@ -562,7 +562,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c2",
+    "dest": ["c2"],
     "src": ["c4"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -573,7 +573,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c5",
+    "dest": ["c5"],
     "src": ["c3", "thera"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -584,7 +584,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["ls", "ns"],
     "static": false,
     "max_mass_per_jump": 2000000000,
@@ -595,7 +595,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c3",
+    "dest": ["c3"],
     "src": ["c3", "thera"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -606,7 +606,7 @@
   },
   {
     "mass_regen": 100000000,
-    "dest": "c4",
+    "dest": ["c4"],
     "src": ["hs", "ls", "ns"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -617,7 +617,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c3",
+    "dest": ["c3"],
     "src": ["c2", "drifter"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -628,7 +628,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c3",
+    "dest": ["c3"],
     "src": ["c1", "ns"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -639,7 +639,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c1",
+    "dest": ["c1"],
     "src": ["c4"],
     "static": true,
     "max_mass_per_jump": 62000000,
@@ -650,7 +650,7 @@
   },
   {
     "mass_regen": "3000000000",
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["c1", "c2", "c3", "c4", "c5", "c6", "thera", "c13"],
     "static": false,
     "max_mass_per_jump": 5000000,
@@ -661,7 +661,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "hs",
+    "dest": ["hs"],
     "src": ["thera"],
     "static": true,
     "max_mass_per_jump": 62000000,
@@ -672,7 +672,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c1",
+    "dest": ["c1"],
     "src": ["c6"],
     "static": true,
     "max_mass_per_jump": 62000000,
@@ -683,7 +683,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["hs"],
     "static": false,
     "max_mass_per_jump": 1000000000,
@@ -694,7 +694,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c4",
+    "dest": ["c4"],
     "src": ["pochven"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -705,7 +705,7 @@
   },
   {
     "mass_regen": null,
-    "dest": "redoubt",
+    "dest": ["redoubt"],
     "src": ["hs", "ls", "ns", "jove"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -716,7 +716,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c6",
+    "dest": ["c6"],
     "src": ["c2", "drifter"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -727,7 +727,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c2",
+    "dest": ["c2"],
     "src": ["hs", "ls", "ns"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -738,7 +738,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "hs",
+    "dest": ["hs"],
     "src": ["c4"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -749,7 +749,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["ls", "ns"],
     "static": false,
     "max_mass_per_jump": 2000000000,
@@ -760,7 +760,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c6",
+    "dest": ["c6"],
     "src": ["c1", "ns"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -771,7 +771,7 @@
   },
   {
     "mass_regen": null,
-    "dest": "sentinel",
+    "dest": ["sentinel"],
     "src": ["hs", "ls", "ns", "jove"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -782,7 +782,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c4",
+    "dest": ["c4"],
     "src": ["c3", "thera"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -793,7 +793,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "thera",
+    "dest": ["thera"],
     "src": ["hs"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -804,7 +804,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["c3", "c4-shattered", "c5-shattered"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -815,7 +815,7 @@
   },
   {
     "mass_regen": 500000000,
-    "dest": "c6",
+    "dest": ["c6"],
     "src": ["ls", "ns"],
     "static": false,
     "max_mass_per_jump": 2000000000,
@@ -826,7 +826,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "pochven",
+    "dest": ["pochven"],
     "src": ["ns"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -837,7 +837,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c6",
+    "dest": ["c6"],
     "src": ["c4"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -848,7 +848,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["hs"],
     "static": false,
     "max_mass_per_jump": 1000000000,
@@ -859,7 +859,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c1",
+    "dest": ["c1"],
     "src": ["c3", "thera"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -870,7 +870,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c6",
+    "dest": ["c6"],
     "src": ["c5"],
     "static": true,
     "max_mass_per_jump": 2000000000,
@@ -881,7 +881,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["thera"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -892,7 +892,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c5",
+    "dest": ["c5"],
     "src": ["c6"],
     "static": true,
     "max_mass_per_jump": 2000000000,
@@ -903,7 +903,7 @@
   },
   {
     "mass_regen": null,
-    "dest": "vidette",
+    "dest": ["vidette"],
     "src": ["hs", "ls", "ns", "jove"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -914,7 +914,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c6",
+    "dest": ["c6"],
     "src": ["c6"],
     "static": true,
     "max_mass_per_jump": 2000000000,
@@ -925,7 +925,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["pochven"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -936,7 +936,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c3",
+    "dest": ["c3"],
     "src": ["hs", "ls", "ns"],
     "static": false,
     "max_mass_per_jump": 375000000,
@@ -947,7 +947,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c4",
+    "dest": ["c4"],
     "src": ["c4"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -958,7 +958,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c4",
+    "dest": ["c4"],
     "src": ["c2", "drifter"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -969,7 +969,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c1",
+    "dest": ["c1"],
     "src": ["c5"],
     "static": true,
     "max_mass_per_jump": 62000000,
@@ -980,7 +980,7 @@
   },
   {
     "mass_regen": "3000000000",
-    "dest": "c3",
+    "dest": ["c3"],
     "src": ["c1", "c2", "c3", "c4", "c5", "c6", "thera", "c13"],
     "static": false,
     "max_mass_per_jump": 5000000,
@@ -991,7 +991,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["c1"],
     "static": true,
     "max_mass_per_jump": 62000000,
@@ -1002,7 +1002,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ns",
+    "dest": ["ns"],
     "src": ["c5", "c6"],
     "static": false,
     "max_mass_per_jump": 2000000000,
@@ -1013,7 +1013,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c4",
+    "dest": ["c4"],
     "src": ["c6"],
     "static": true,
     "max_mass_per_jump": 375000000,
@@ -1024,7 +1024,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c1",
+    "dest": ["c1"],
     "src": ["c2", "drifter"],
     "static": true,
     "max_mass_per_jump": 62000000,
@@ -1035,7 +1035,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "c1",
+    "dest": ["c1"],
     "src": ["hs", "ls", "ns"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -1046,7 +1046,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "ls",
+    "dest": ["ls"],
     "src": ["c1", "c2", "c3", "c4", "c5", "c6"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -1068,7 +1068,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "pochven",
+    "dest": ["pochven"],
     "src": ["pochven"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -1079,7 +1079,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "pochven",
+    "dest": ["pochven"],
     "src": ["pochven"],
     "static": false,
     "max_mass_per_jump": 62000000,
@@ -1090,7 +1090,7 @@
   },
   {
     "mass_regen": 0,
-    "dest": "pochven",
+    "dest": ["pochven"],
     "src": ["pochven"],
     "static": false,
     "max_mass_per_jump": 62000000,

--- a/priv/repo/data/wormholes.json
+++ b/priv/repo/data/wormholes.json
@@ -177,14 +177,14 @@
   },
   {
     "mass_regen": 0,
-    "dest": "pochven",
-    "src": ["hs", "ls", "ns", "pochven"],
-    "static": false,
+    "dest": null,
+    "src": ["pochven"],
+    "static": true,
     "max_mass_per_jump": 1000000000,
     "lifetime": "12",
     "total_mass": 1000000000,
     "name": "C729",
-    "respawn": ["wandering", "reverse"]
+    "respawn": ["static"]
   },
   {
     "mass_regen": 0,


### PR DESCRIPTION
The main objective of this PR was the reversal of C729 wormholes by making them static on Pochven and outgoing to K-space and Pochven systems as of patch 2026-03-18.1:
<img width="820" height="90" alt="imagen" src="https://github.com/user-attachments/assets/39003ddb-4411-447b-bb85-c2bf61ba6a8a" />

But due to the fact that, outside of the special case of K162, no wormhole has ever lead to multiple system classes, it also meant reworking the application to allow just that. It closes my issue here: https://github.com/wanderer-industries/wanderer/issues/600; as well as an issue and FR in Discord for the same

The main changes of this PR:
- Make all wormholes accept an array of class destinations.
  - For All but C729 and K162, I just made the previous destination be an array of said single element.
  - For K162, its value of `null` stays to help keeping its old behavior.
- Reverse C729 `src` and `dest` values, mark as `static` and replace `"reverse"`and `"wandering"` for just `"static"`.
- Make C729 static to all 27 Pochven systems
- Add the "K162 Type" field to C729 types during Signature edition. Renamed to "Destination Class" and as well as name files and variables to make it more generic for any future wormhole with multiple destinations:
  - For K162, no changes.
  - For C729, only K-space security classes and Pochven are listed
- During signature edition, if multiple systems are connected, "Leads to" will filter for only allowed outgoing connections (K-space or Pochven)
- As with K162 wormholes:
  - C729s will show the destination class appended to its WH class name (ex: C729 High-Sec) on the system signatures panel when no target system is linked yet to it.
  - C729s unsplashed signature will appear with the selected target class color if set; or default color if none.
- Signature linking, by connecting from anchor to anchor or when the WH jump is tracked, will filter correctly depending if "Destination Class" is set on C729 (only show on matching-class systems) or not (any K-space + Pochven)
  - Similar to K162. If C729 has High-Sec defined and linked system is Low-Sec it won't appear on the list. If it was High-Sec it would be.
- Wormhole References dialog has the updated info for C729, as in "Leads to Pochven", "static".

If there's anything you feel it's missing, or any changes you want, feel free to tell.

Screenshots:
- C729 shows as static:
<img width="396" height="457" alt="imagen" src="https://github.com/user-attachments/assets/628b1902-b846-4527-835d-06ac78bd1a45" />

- Renamed "K162 Type:" field shows when type is C729 as well:
<img width="399" height="481" alt="imagen" src="https://github.com/user-attachments/assets/a1d25001-cb72-44ea-9098-a89cd82a45f4" />

- Various wromhole tests with different types, target class, lead to system, EOL/mass status:
<img width="401" height="378" alt="imagen" src="https://github.com/user-attachments/assets/95c22ba7-3034-476b-a228-bcb3e02b2142" />

- All C729 cases in signature panel and visualization on map:
<img width="1119" height="363" alt="imagen" src="https://github.com/user-attachments/assets/7392bc8c-ac2e-4d7d-97c7-026dc22bff2e" />

- Linking between anchors from Pochven to Hi-Sec system, showcasing the filtering:
<img width="600" height="457" alt="imagen" src="https://github.com/user-attachments/assets/7e9c41f5-1e3e-4ee0-9a6f-b27d5f949ef7" />

- Same but to a C4 WH, all C729 are filtered out:
<img width="705" height="331" alt="imagen" src="https://github.com/user-attachments/assets/9fb19071-dace-4967-8e5c-d4ae2883910d" />

- Even with C2 connected, only linked Null-Sec and Pochven appear in "Leads To:" for C729:
<img width="644" height="572" alt="imagen" src="https://github.com/user-attachments/assets/79f6c194-c519-4eb5-b3e6-7c8b5be6199a" />

- Updated Wormhole Reference info for C729:
<img width="943" height="234" alt="imagen" src="https://github.com/user-attachments/assets/21392eaf-3bbf-4319-930c-5b1e10edc443" />
