### PR TITLE
fix: missing Vale statics

### DIFF
--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureWormholeTypeSelect/SignatureWormholeTypeSelect.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/components/SignatureWormholeTypeSelect/SignatureWormholeTypeSelect.tsx
@@ -32,7 +32,7 @@ const getPossibleWormholes = (systemStatic: SolarSystemStaticInfoRaw, wormholes:
   return {
     statics: possibleWHTypes
       .filter(x => x.respawn.some(y => y === Respawn.static))
-      .filter(x => systemStatic.statics.includes(x.name)),
+      .filter(x => systemStatic.statics?.includes(x.name)),
     k162: wormholes.find(x => x.name === 'K162')!,
     wanderings: possibleWHTypes.filter(x => x.respawn.some(y => y === Respawn.wandering)),
   };

--- a/priv/repo/data/triglavianSystems.json
+++ b/priv/repo/data/triglavianSystems.json
@@ -262,6 +262,9 @@
    {
       "solarSystemName": "Vale",
       "solarSystemID": 30005029,
+      "statics": [
+        "C729"
+      ],
       "effectName": "Dazh Liminality Locus",
       "effectPower": 1,
       "invasionStatus": "Final"

--- a/test/unit/map/server/k162_backlink_preference_test.exs
+++ b/test/unit/map/server/k162_backlink_preference_test.exs
@@ -79,7 +79,7 @@ defmodule WandererApp.Map.Server.K162BacklinkPreferenceTest do
           group: "Wormhole",
           linked_system_id: 30_000_143,
           custom_info:
-            Jason.encode!(%{"time_status" => 1, "mass_status" => 1, "k162Type" => nil})
+            Jason.encode!(%{"time_status" => 1, "mass_status" => 1, "destType" => nil})
         })
 
       # find_forward_signature looks in the target system (system_b.id)
@@ -223,7 +223,7 @@ defmodule WandererApp.Map.Server.K162BacklinkPreferenceTest do
           type: "K162",
           group: "Wormhole",
           custom_info:
-            Jason.encode!(%{"time_status" => 0, "mass_status" => 0, "k162Type" => "C2"})
+            Jason.encode!(%{"time_status" => 0, "mass_status" => 0, "destType" => "C2"})
         })
 
       # Simulate what the linking code does: update K162's custom_info
@@ -256,8 +256,8 @@ defmodule WandererApp.Map.Server.K162BacklinkPreferenceTest do
       decoded = Jason.decode!(updated_sig.custom_info)
       assert decoded["time_status"] == 1
       assert decoded["mass_status"] == 1
-      # k162Type should be preserved
-      assert decoded["k162Type"] == "C2"
+      # destType should be preserved
+      assert decoded["destType"] == "C2"
     end
 
     test "K162 custom_info update preserves existing fields", %{map: map} do
@@ -274,7 +274,7 @@ defmodule WandererApp.Map.Server.K162BacklinkPreferenceTest do
             Jason.encode!(%{
               "time_status" => 0,
               "mass_status" => 0,
-              "k162Type" => "C5",
+              "destType" => "C5",
               "extra_field" => "preserved"
             })
         })
@@ -310,7 +310,7 @@ defmodule WandererApp.Map.Server.K162BacklinkPreferenceTest do
       # mass_status should remain unchanged (nil signature_mass_status)
       assert decoded["mass_status"] == 0
       # Other fields should be preserved
-      assert decoded["k162Type"] == "C5"
+      assert decoded["destType"] == "C5"
       assert decoded["extra_field"] == "preserved"
     end
 


### PR DESCRIPTION
Small error after the C729 changes. Vale didn't have `statics` filled, and made a check to avoid breaking if `statics` is `null` or `undefined` before using `.includes()`.

Also reworded the name of `k162Type` in tests to match actual code after changes.

Sorry for any issues due to the bug.