### PR TITLE
feat: Add UI indicators for signature time and mass statuses

### DIFF
--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/renders/renderInfoColumn.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemSignatures/renders/renderInfoColumn.tsx
@@ -22,13 +22,31 @@ export const renderInfoColumn = (row: SystemSignature) => {
 
         {customInfo.time_status === TimeStatus._1h && (
           <WdTooltipWrapper offset={5} position={TooltipPosition.bottom} content="Signature marked as EOL">
+            <div className="pi pi-clock text-red-400 text-[11px] mr-[2px]"></div>
+          </WdTooltipWrapper>
+        )}
+
+        {customInfo.time_status === TimeStatus._4h && (
+          <WdTooltipWrapper offset={5} position={TooltipPosition.bottom} content="Signature marked as 4H EOL">
             <div className="pi pi-clock text-fuchsia-400 text-[11px] mr-[2px]"></div>
+          </WdTooltipWrapper>
+        )}
+
+        {customInfo.time_status === TimeStatus._4h30m && (
+          <WdTooltipWrapper offset={5} position={TooltipPosition.bottom} content="Signature marked as 4.5H EOL">
+            <div className="pi pi-clock text-indigo-300 text-[11px] mr-[2px]"></div>
           </WdTooltipWrapper>
         )}
 
         {customInfo.isCrit && (
           <WdTooltipWrapper offset={5} position={TooltipPosition.bottom} content="Signature marked as Crit">
             <div className="pi pi-clock text-fuchsia-400 text-[11px] mr-[2px]"></div>
+          </WdTooltipWrapper>
+        )}
+
+        {customInfo.mass_status === MassState.half && (
+          <WdTooltipWrapper offset={5} position={TooltipPosition.bottom} content="Signature marked as Half mass">
+            <div className="pi pi-exclamation-triangle text-orange-300 text-[11px] mr-[2px]"></div>
           </WdTooltipWrapper>
         )}
 


### PR DESCRIPTION
## Description
Adds visual indicators (icons and tooltips) to the system signatures info column to better communicate the time and mass status of wormholes.

### Changes Made
* Added a red clock icon tooltip for **1H EOL** (`TimeStatus._1h`).
* Added a fuchsia clock icon tooltip for **4H EOL** (`TimeStatus._4h`).
* Added an indigo clock icon tooltip for **4.5H EOL** (`TimeStatus._4h30m`).
* Added an orange warning triangle icon tooltip for **Half mass** (`MassState.half`).


<img width="327" height="118" alt="image" src="https://github.com/user-attachments/assets/0c307366-54cd-4d10-983c-6881854f09a0" />
