### PR TITLE
Fix bookmark custom mapping save behavior & add K162 size formatting

### DIFF
--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/BookmarkNameFormatSetting.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/BookmarkNameFormatSetting.tsx
@@ -70,21 +70,21 @@ const CustomMappingInput = ({
 
   const handleBlur = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
     const val = e.target.value;
-    setLocalMapping(prev => {
-      const newMapping = { ...prev };
-      if (val === defaultVal) {
-        delete newMapping[mappingKey];
-      } else {
-        newMapping[mappingKey] = val;
-      }
+    
+    const newMapping = { ...localMapping };
+    if (val === defaultVal) {
+      delete newMapping[mappingKey];
+    } else {
+      newMapping[mappingKey] = val;
+    }
 
-      const savedVal = savedMapping[mappingKey] !== undefined ? savedMapping[mappingKey] : defaultVal;
-      if (val === savedVal) return newMapping;
+    setLocalMapping(newMapping);
 
+    const savedVal = savedMapping[mappingKey] !== undefined ? savedMapping[mappingKey] : defaultVal;
+    if (val !== savedVal) {
       updateSetting(UserSettingsRemoteProps.bookmark_custom_mapping, newMapping);
-      return newMapping;
-    });
-  }, [mappingKey, defaultVal, savedMapping, setLocalMapping, updateSetting]);
+    }
+  }, [mappingKey, defaultVal, savedMapping, localMapping, setLocalMapping, updateSetting]);
 
   return (
     <div className="flex flex-col gap-1 w-[120px]">

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/BookmarkNameFormatSetting.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/BookmarkNameFormatSetting.tsx
@@ -43,6 +43,7 @@ interface CustomMappingInputProps {
   mappingKey: string;
   label: string;
   defaultVal: string;
+  savedMapping: Record<string, string>;
   localMapping: Record<string, string>;
   setLocalMapping: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   updateSetting: (prop: any, value: any) => void;
@@ -52,6 +53,7 @@ const CustomMappingInput = ({
   mappingKey,
   label,
   defaultVal,
+  savedMapping,
   localMapping,
   setLocalMapping,
   updateSetting,
@@ -78,10 +80,16 @@ const CustomMappingInput = ({
       } else {
         newMapping[mappingKey] = val;
       }
-      updateSetting(UserSettingsRemoteProps.bookmark_custom_mapping, newMapping);
+
+      const savedVal = savedMapping[mappingKey] !== undefined ? savedMapping[mappingKey] : defaultVal;
+      const newVal = newMapping[mappingKey] !== undefined ? newMapping[mappingKey] : defaultVal;
+
+      if (newVal !== savedVal) {
+        updateSetting(UserSettingsRemoteProps.bookmark_custom_mapping, newMapping);
+      }
       return newMapping;
     });
-  }, [mappingKey, defaultVal, setLocalMapping, updateSetting]);
+  }, [mappingKey, defaultVal, savedMapping, setLocalMapping, updateSetting]);
 
   return (
     <div className="flex flex-col gap-1 w-[120px]">
@@ -120,6 +128,7 @@ const SIZE_OPTIONS = [
   { key: 'size_large', label: 'Large', defaultVal: '' },
   { key: 'size_freight', label: 'Huge / Freight', defaultVal: 'XL' },
   { key: 'size_capital', label: 'Capital', defaultVal: 'C' },
+  { key: 'size_k162_unknown', label: 'Unknown (K162)', defaultVal: '' },
 ];
 
 const CLASS_OPTIONS = [
@@ -248,6 +257,7 @@ export const BookmarkNameFormatSetting = () => {
         mappingKey={opt.key}
         label={opt.label}
         defaultVal={opt.defaultVal}
+        savedMapping={customMapping}
         localMapping={localMapping}
         setLocalMapping={setLocalMapping}
         updateSetting={updateSetting}

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/BookmarkNameFormatSetting.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/BookmarkNameFormatSetting.tsx
@@ -71,9 +71,6 @@ const CustomMappingInput = ({
   const handleBlur = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
     const val = e.target.value;
     setLocalMapping(prev => {
-      const currentVal = prev[mappingKey] !== undefined ? prev[mappingKey] : defaultVal;
-      if (val === currentVal) return prev;
-
       const newMapping = { ...prev };
       if (val === defaultVal) {
         delete newMapping[mappingKey];
@@ -82,11 +79,9 @@ const CustomMappingInput = ({
       }
 
       const savedVal = savedMapping[mappingKey] !== undefined ? savedMapping[mappingKey] : defaultVal;
-      const newVal = newMapping[mappingKey] !== undefined ? newMapping[mappingKey] : defaultVal;
+      if (val === savedVal) return newMapping;
 
-      if (newVal !== savedVal) {
-        updateSetting(UserSettingsRemoteProps.bookmark_custom_mapping, newMapping);
-      }
+      updateSetting(UserSettingsRemoteProps.bookmark_custom_mapping, newMapping);
       return newMapping;
     });
   }, [mappingKey, defaultVal, savedMapping, setLocalMapping, updateSetting]);

--- a/assets/js/hooks/Mapper/constants.ts
+++ b/assets/js/hooks/Mapper/constants.ts
@@ -93,7 +93,7 @@ export const ALL_DEST_TYPES: DestinationType[] = [
   {
     label: 'C1',
     value: 'c1',
-    whClassName: 'E004',
+    whClassName: 'Z971',
   },
   {
     label: 'C2',
@@ -108,7 +108,7 @@ export const ALL_DEST_TYPES: DestinationType[] = [
   {
     label: 'C4',
     value: 'c4',
-    whClassName: 'M001',
+    whClassName: 'Z457',
   },
   {
     label: 'C5',
@@ -138,12 +138,12 @@ export const ALL_DEST_TYPES: DestinationType[] = [
   {
     label: 'C1/C2/C3',
     value: 'c1_c2_c3',
-    whClassName: 'E004_D382_L477',
+    whClassName: 'Z971_D382_L477',
   },
   {
     label: 'C4/C5',
     value: 'c4_c5',
-    whClassName: 'M001_L614',
+    whClassName: 'Z457_L614',
   },
 ];
 

--- a/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
+++ b/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
@@ -304,7 +304,7 @@ export const formatBookmarkName = (
       const whName = k162Option.whClassName.split('_')[0];
       whDataForSize = wormholesData[whName];
     }
-  } else if (signature.type && wormholesData[signature.type]) {
+  } else if (signature.type && !MULTI_DEST_WHS.includes(signature.type) && wormholesData[signature.type]) {
     whDataForSize = wormholesData[signature.type];
   }
 
@@ -334,6 +334,10 @@ export const formatBookmarkName = (
     }
     if (whDataForSize.total_mass) {
       massStr = Number((whDataForSize.total_mass / 1_000_000_000).toFixed(2)).toString();
+    }
+  } else if (signature.type === 'K162') {
+    if (mapping && mapping['size_k162_unknown'] !== undefined) {
+      sizeStr = mapping['size_k162_unknown'];
     }
   }
   result = result.replace(/\{size\}/g, () => sizeStr);

--- a/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
+++ b/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
@@ -292,16 +292,14 @@ export const formatBookmarkName = (
   let massStr = '';
   let whDataForSize: WormholeDataRaw | null = null;
 
-  if (signature.type && MULTI_DEST_WHS.includes(signature.type) && info.destType) {
-    const destOption = ALL_DEST_TYPES_MAP[info.destType];
-    if (destOption && destOption.whClassName) {
+  const isK162 = signature.type === 'K162';
+  const isMultiDest = !!signature.type && MULTI_DEST_WHS.includes(signature.type);
+  const destType = isK162 ? info.k162Type : info.destType;
+
+  if ((isK162 || isMultiDest) && destType) {
+    const destOption = ALL_DEST_TYPES_MAP[destType];
+    if (destOption?.whClassName) {
       const whName = destOption.whClassName.split('_')[0];
-      whDataForSize = wormholesData[whName];
-    }
-  } else if (signature.type === 'K162' && info.k162Type) {
-    const k162Option = ALL_DEST_TYPES_MAP[info.k162Type];
-    if (k162Option && k162Option.whClassName) {
-      const whName = k162Option.whClassName.split('_')[0];
       whDataForSize = wormholesData[whName];
     }
   } else if (signature.type && !MULTI_DEST_WHS.includes(signature.type) && wormholesData[signature.type]) {

--- a/lib/wanderer_app/map/operations/connections.ex
+++ b/lib/wanderer_app/map/operations/connections.ex
@@ -149,9 +149,6 @@ defmodule WandererApp.Map.Operations.Connections do
       c13_system?(src, tgt) ->
         @small_ship_size
 
-      c4_to_ns?(src, tgt) ->
-        @small_ship_size
-
       true ->
         @large_ship_size
     end
@@ -173,19 +170,6 @@ defmodule WandererApp.Map.Operations.Connections do
   defp c13_system?(%{system_class: @c13_system_class}, _), do: true
   defp c13_system?(_, %{system_class: @c13_system_class}), do: true
   defp c13_system?(_, _), do: false
-
-  defp c4_to_ns?(%{system_class: @c4_system_class, is_shattered: false}, %{
-         system_class: @ns_system_class
-       }),
-       do: true
-
-  defp c4_to_ns?(%{system_class: @ns_system_class}, %{
-         system_class: @c4_system_class,
-         is_shattered: false
-       }),
-       do: true
-
-  defp c4_to_ns?(_, _), do: false
 
   defp parse_ship_size(nil, default), do: default
   defp parse_ship_size(val, _default) when is_integer(val), do: val


### PR DESCRIPTION
**Overview**
This merge request addresses an issue where advanced bookmark custom mapping settings were not saving reliably, and introduces a new size mapping option for Unknown (K162) signatures. 

**Key Changes:**
* **Fixed `updateSetting` side effects:** Refactored `CustomMappingInput` to move the `updateSetting` call outside of the `setLocalMapping` React state setter function. This ensures the remote settings correctly update when the input loses focus.
* **Improved change detection:** The `handleBlur` event handler now determines whether an update is necessary by directly comparing the new input value to the externally saved value (`savedMapping`), rather than relying on the previous local state.
* **Added K162 size mappings:** Introduced a new custom size mapping option for `Unknown (K162)` signatures in the Bookmark Name Format Settings UI.
* **Updated format helper:** Modified `formatBookmarkName` in `bookmarkFormatHelper.ts` to apply the new K162 size mapping and correctly exclude multi-destination wormholes from standard size evaluations to avoid mapping collisions.
* **Updated wormhole classes:** Updated `whClassName` values for C1 and C4 destination types.
* **Refactored bookmark formatting logic:** Consolidated K162 and multi-destination checks in the bookmark formatting helper.
* **Fixed connection operations:** Removed `c4_to_ns?` check and small ship size constraint from connection operations.

Let me know if you would like any adjustments to this!