### PR TITLE
fix: authorize client-supplied IDs in LiveView handlers (IDOR audit)

### DIFF
--- a/lib/wanderer_app_web/handler_auth.ex
+++ b/lib/wanderer_app_web/handler_auth.ex
@@ -1,0 +1,168 @@
+defmodule WandererAppWeb.HandlerAuth do
+  @moduledoc """
+  Authorization helpers used by LiveView event handlers to verify that a
+  client-supplied record id belongs to the map (or user) currently in scope.
+
+  These helpers exist because LiveView `handle_event` callbacks receive
+  unvalidated client params. A malicious client can submit any UUID it likes;
+  the server must check that the record actually belongs to the authenticated
+  context before acting on it.
+
+  Each helper returns `{:ok, record}` when the lookup succeeds AND the record
+  is scoped to the given context, or `{:error, :not_found}` otherwise.
+
+  We deliberately return `:not_found` (rather than `:unauthorized`) for both
+  the "record does not exist" and "record exists but on a different map"
+  cases — this avoids leaking the existence of records in other contexts.
+  """
+
+  @doc """
+  Returns `{:ok, subscription}` if the subscription exists and belongs to `map_id`,
+  `{:error, :not_found}` otherwise.
+  """
+  def authorize_subscription(subscription_id, map_id) when is_binary(map_id) do
+    with {:ok, subscription} <- WandererApp.Api.MapSubscription.by_id(subscription_id),
+         true <- subscription.map_id == map_id do
+      {:ok, subscription}
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  def authorize_subscription(_subscription_id, _map_id), do: {:error, :not_found}
+
+  @doc """
+  Returns `{:ok, character}` if the character exists and is owned by `user_id`,
+  `{:error, :not_found}` otherwise.
+  """
+  def authorize_character(character_id, user_id) when is_binary(user_id) do
+    with {:ok, character} <- WandererApp.Api.Character.by_id(character_id),
+         true <- character.user_id == user_id do
+      {:ok, character}
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  def authorize_character(_character_id, _user_id), do: {:error, :not_found}
+
+  @doc """
+  Returns `{:ok, ping}` if the ping exists and belongs to `map_id`,
+  `{:error, :not_found}` otherwise.
+
+  Uses the `:all_pings` read action (which has no actor filter) so the
+  helper can do the map-scoping check itself. The primary `:read` action's
+  `FilterPingsByActorMap` preparation is for token-based API auth and is
+  not applicable in the LiveView context.
+  """
+  def authorize_ping(ping_id, map_id) when is_binary(map_id) do
+    require Ash.Query
+
+    result =
+      WandererApp.Api.MapPing
+      |> Ash.Query.for_read(:all_pings)
+      |> Ash.Query.filter(id == ^ping_id)
+      |> Ash.read_one()
+
+    case result do
+      {:ok, %{} = ping} ->
+        if ping.map_id == map_id, do: {:ok, ping}, else: {:error, :not_found}
+
+      _ ->
+        {:error, :not_found}
+    end
+  end
+
+  def authorize_ping(_ping_id, _map_id), do: {:error, :not_found}
+
+  @doc """
+  Returns `{:ok, comment}` if the comment's system belongs to `map_id`,
+  `{:error, :not_found}` otherwise.
+
+  Comments live on a system (`comment.system_id`), and we want the comment's
+  system to belong to the current map.
+  """
+  def authorize_system_comment(comment_id, map_id) when is_binary(map_id) do
+    with {:ok, comment} <- WandererApp.MapSystemCommentRepo.get_by_id(comment_id),
+         {:ok, system} <- WandererApp.Api.MapSystem.by_id(comment.system_id),
+         true <- system.map_id == map_id do
+      {:ok, comment}
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  def authorize_system_comment(_comment_id, _map_id), do: {:error, :not_found}
+
+  @doc """
+  Returns `{:ok, passage}` if the passage exists and belongs to `map_id`,
+  `{:error, :not_found}` otherwise.
+  """
+  def authorize_passage(passage_id, map_id) when is_binary(map_id) do
+    with {:ok, passage} when not is_nil(passage) <-
+           WandererApp.Api.MapChainPassages.by_id(passage_id),
+         true <- passage.map_id == map_id do
+      {:ok, passage}
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  def authorize_passage(_passage_id, _map_id), do: {:error, :not_found}
+
+  @doc """
+  Returns `true` if the given `eve_id` matches any character in the user's
+  loaded character list.
+  """
+  def user_owns_character_eve_id?(user_characters, eve_id) when is_list(user_characters) do
+    eve_id_str = "#{eve_id}"
+    Enum.any?(user_characters, fn c -> "#{c.eve_id}" == eve_id_str end)
+  end
+
+  def user_owns_character_eve_id?(_user_characters, _eve_id), do: false
+
+  @doc """
+  Parses a client-supplied subscription period (in months).
+
+  Returns `{:ok, n}` only for values offered by the form select
+  (1, 3, 6, or 12 months). Anything else — non-numeric strings, negative
+  numbers, very large numbers — returns `{:error, message}`.
+
+  This blocks the negative-period exploit where `period: "-1"` produces
+  a back-dated subscription and flips the price calculation to negative.
+  """
+  @valid_subscription_periods [1, 3, 6, 12]
+  def parse_subscription_period(period) when is_binary(period) do
+    case Integer.parse(period) do
+      {n, ""} when n in @valid_subscription_periods -> {:ok, n}
+      _ -> {:error, "Invalid subscription period."}
+    end
+  end
+
+  def parse_subscription_period(_), do: {:error, "Invalid subscription period."}
+
+  @doc """
+  Parses a client-supplied `characters_limit` value. The form range input
+  allows 50..5000 step 50; anything outside that range is rejected.
+  """
+  def parse_characters_limit(value), do: parse_bounded_int(value, 50, 5_000, "characters limit")
+
+  @doc """
+  Parses a client-supplied `hubs_limit` value. The form range input
+  allows 20..50 step 10; anything outside that range is rejected.
+  """
+  def parse_hubs_limit(value), do: parse_bounded_int(value, 20, 50, "hubs limit")
+
+  defp parse_bounded_int(value, min, max, label) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, ""} when n >= min and n <= max -> {:ok, n}
+      _ -> {:error, "Invalid #{label}."}
+    end
+  end
+
+  defp parse_bounded_int(value, min, max, _label)
+       when is_integer(value) and value >= min and value <= max,
+       do: {:ok, value}
+
+  defp parse_bounded_int(_, _, _, label), do: {:error, "Invalid #{label}."}
+end

--- a/lib/wanderer_app_web/live/characters/characters_live.ex
+++ b/lib/wanderer_app_web/live/characters/characters_live.ex
@@ -78,26 +78,32 @@ defmodule WandererAppWeb.CharactersLive do
 
   @impl true
   def handle_event("delete", %{"character_id" => character_id}, socket) do
-    WandererApp.Character.TrackerManager.stop_tracking(character_id)
+    user_id = socket.assigns.user_id
 
-    {:ok, map_character_settings} =
-      WandererApp.Api.MapCharacterSettings.tracked_by_character(%{character_id: character_id})
+    case WandererAppWeb.HandlerAuth.authorize_character(character_id, user_id) do
+      {:ok, character} ->
+        WandererApp.Character.TrackerManager.stop_tracking(character_id)
 
-    map_character_settings
-    |> Enum.each(fn settings ->
-      {:ok, _} = WandererApp.MapCharacterSettingsRepo.untrack(settings)
-    end)
+        {:ok, map_character_settings} =
+          WandererApp.Api.MapCharacterSettings.tracked_by_character(%{character_id: character_id})
 
-    # Load character from DB instead of using plain map from assigns
-    {:ok, character} = WandererApp.Api.Character.by_id(character_id)
-    {:ok, _updated_character} = WandererApp.Api.Character.mark_as_deleted(character)
+        map_character_settings
+        |> Enum.each(fn settings ->
+          {:ok, _} = WandererApp.MapCharacterSettingsRepo.untrack(settings)
+        end)
 
-    WandererApp.Character.update_character(character_id, %{deleted: true, user_id: nil})
+        {:ok, _updated_character} = WandererApp.Api.Character.mark_as_deleted(character)
 
-    {:ok, characters} =
-      WandererApp.Api.Character.active_by_user(%{user_id: socket.assigns.user_id})
+        WandererApp.Character.update_character(character_id, %{deleted: true, user_id: nil})
 
-    {:noreply, socket |> assign(characters: characters |> Enum.map(&map_ui_character/1))}
+        {:ok, characters} =
+          WandererApp.Api.Character.active_by_user(%{user_id: user_id})
+
+        {:noreply, socket |> assign(characters: characters |> Enum.map(&map_ui_character/1))}
+
+      {:error, :not_found} ->
+        {:noreply, socket |> put_flash(:error, "Character not found.")}
+    end
   end
 
   @impl true

--- a/lib/wanderer_app_web/live/map/event_handlers/map_characters_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_characters_event_handler.ex
@@ -162,36 +162,47 @@ defmodule WandererAppWeb.MapCharactersEventHandler do
         %{
           assigns: %{
             map_id: map_id,
-            current_user: %{id: current_user_id},
+            current_user: %{id: current_user_id, characters: current_user_characters},
             only_tracked_characters: only_tracked_characters
           }
         } = socket
       ) do
-    case WandererApp.Character.TrackingUtils.update_tracking(
-           map_id,
-           character_eve_id,
-           current_user_id,
-           track,
-           self(),
-           only_tracked_characters
-         ) do
-      {:ok, tracking_data, event} when not is_nil(tracking_data) ->
-        # Send the appropriate event based on the result
-        Process.send_after(self(), event, 50)
+    if WandererAppWeb.HandlerAuth.user_owns_character_eve_id?(
+         current_user_characters,
+         character_eve_id
+       ) do
+      case WandererApp.Character.TrackingUtils.update_tracking(
+             map_id,
+             character_eve_id,
+             current_user_id,
+             track,
+             self(),
+             only_tracked_characters
+           ) do
+        {:ok, tracking_data, event} when not is_nil(tracking_data) ->
+          # Send the appropriate event based on the result
+          Process.send_after(self(), event, 50)
 
-        # Send the updated tracking data to the client
-        {:reply, %{data: tracking_data}, socket}
+          # Send the updated tracking data to the client
+          {:reply, %{data: tracking_data}, socket}
 
-      {:ok, nil, event} ->
-        # Send the appropriate event based on the result
-        Process.send_after(self(), event, 50)
+        {:ok, nil, event} ->
+          # Send the appropriate event based on the result
+          Process.send_after(self(), event, 50)
 
-        # Send the updated tracking data to the client
-        {:reply, %{characters: []}, socket}
+          # Send the updated tracking data to the client
+          {:reply, %{characters: []}, socket}
 
-      {:error, reason} ->
-        Logger.error("Failed to toggle track: #{inspect(reason)}")
-        {:noreply, socket |> put_flash(:error, "Failed to toggle character tracking")}
+        {:error, reason} ->
+          Logger.error("Failed to toggle track: #{inspect(reason)}")
+          {:noreply, socket |> put_flash(:error, "Failed to toggle character tracking")}
+      end
+    else
+      Logger.warning(
+        "updateCharacterTracking rejected: user #{current_user_id} does not own character #{character_eve_id}"
+      )
+
+      {:noreply, socket}
     end
   end
 

--- a/lib/wanderer_app_web/live/map/event_handlers/map_connections_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_connections_event_handler.ex
@@ -271,6 +271,7 @@ defmodule WandererAppWeb.MapConnectionsEventHandler do
         %{"id" => passage_id, "mass" => mass} = _event,
         %{
           assigns: %{
+            map_id: map_id,
             has_tracked_characters?: true,
             user_permissions: %{update_system: true}
           }
@@ -291,12 +292,14 @@ defmodule WandererAppWeb.MapConnectionsEventHandler do
           nil
       end
 
-    case WandererApp.Api.MapChainPassages.by_id(passage_id) do
-      {:ok, passage} when not is_nil(passage) ->
+    case WandererAppWeb.HandlerAuth.authorize_passage(passage_id, map_id) do
+      {:ok, passage} ->
         WandererApp.Api.MapChainPassages.update_mass(passage, %{mass: mass_value})
 
-      _ ->
-        Logger.warning("update_passage_mass: passage not found id=#{passage_id}")
+      {:error, :not_found} ->
+        Logger.warning(
+          "update_passage_mass rejected: passage #{inspect(passage_id)} not on map #{map_id}"
+        )
     end
 
     {:noreply, socket}

--- a/lib/wanderer_app_web/live/map/event_handlers/map_pings_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_pings_event_handler.ex
@@ -157,13 +157,19 @@ defmodule WandererAppWeb.MapPingsEventHandler do
           socket
       )
       when not is_nil(main_character_id) do
-    map_id
-    |> WandererApp.Map.Server.cancel_ping(%{
-      id: id,
-      type: type,
-      character_id: main_character_id,
-      user_id: current_user.id
-    })
+    case WandererAppWeb.HandlerAuth.authorize_ping(id, map_id) do
+      {:ok, _ping} ->
+        map_id
+        |> WandererApp.Map.Server.cancel_ping(%{
+          id: id,
+          type: type,
+          character_id: main_character_id,
+          user_id: current_user.id
+        })
+
+      {:error, :not_found} ->
+        Logger.warning("cancel_ping rejected: ping #{inspect(id)} not on map #{map_id}")
+    end
 
     {:noreply, socket}
   end

--- a/lib/wanderer_app_web/live/map/event_handlers/map_system_comments_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_system_comments_event_handler.ex
@@ -136,12 +136,20 @@ defmodule WandererAppWeb.MapSystemCommentsEventHandler do
           socket
       )
       when not is_nil(main_character_id) do
-    map_id
-    |> WandererApp.Map.Server.remove_system_comment(
-      comment_id,
-      current_user.id,
-      main_character_id
-    )
+    case WandererAppWeb.HandlerAuth.authorize_system_comment(comment_id, map_id) do
+      {:ok, _comment} ->
+        map_id
+        |> WandererApp.Map.Server.remove_system_comment(
+          comment_id,
+          current_user.id,
+          main_character_id
+        )
+
+      {:error, :not_found} ->
+        Logger.warning(
+          "deleteSystemComment rejected: comment #{inspect(comment_id)} not on map #{map_id}"
+        )
+    end
 
     {:noreply, socket}
   end

--- a/lib/wanderer_app_web/live/maps/components/map_subscriptions_component.ex
+++ b/lib/wanderer_app_web/live/maps/components/map_subscriptions_component.ex
@@ -71,37 +71,49 @@ defmodule WandererAppWeb.Maps.MapSubscriptionsComponent do
     do: {:noreply, socket |> assign(is_adding_subscription?: true)}
 
   @impl true
-  def handle_event("edit-subscription", %{"id" => subscription_id} = _event, socket) do
-    {:ok, selected_subscription} =
-      subscription_id
-      |> WandererApp.Api.MapSubscription.by_id()
+  def handle_event(
+        "edit-subscription",
+        %{"id" => subscription_id} = _event,
+        %{assigns: %{map_id: map_id}} = socket
+      ) do
+    case WandererAppWeb.HandlerAuth.authorize_subscription(subscription_id, map_id) do
+      {:ok, selected_subscription} ->
+        subscription_form = %{
+          "plan" => "omega",
+          "characters_limit" => "#{selected_subscription.characters_limit}",
+          "hubs_limit" => "#{selected_subscription.hubs_limit}",
+          "auto_renew?" => selected_subscription.auto_renew?,
+          "promo_code" => ""
+        }
 
-    subscription_form = %{
-      "plan" => "omega",
-      "characters_limit" => "#{selected_subscription.characters_limit}",
-      "hubs_limit" => "#{selected_subscription.hubs_limit}",
-      "auto_renew?" => selected_subscription.auto_renew?,
-      "promo_code" => ""
-    }
+        {:ok, additional_price, discount, _promo_valid?} =
+          SubscriptionManager.calc_additional_price(
+            subscription_form,
+            selected_subscription
+          )
 
-    {:ok, additional_price, discount, _promo_valid?} =
-      SubscriptionManager.calc_additional_price(
-        subscription_form,
-        selected_subscription
-      )
+        {:noreply,
+         socket
+         |> assign(
+           is_adding_subscription?: true,
+           selected_subscription: selected_subscription,
+           additional_price: additional_price,
+           discount: discount,
+           promo_code: "",
+           promo_code_valid?: false,
+           promo_code_error: nil,
+           subscription_form: subscription_form |> to_form()
+         )}
 
-    {:noreply,
-     socket
-     |> assign(
-       is_adding_subscription?: true,
-       selected_subscription: selected_subscription,
-       additional_price: additional_price,
-       discount: discount,
-       promo_code: "",
-       promo_code_valid?: false,
-       promo_code_error: nil,
-       subscription_form: subscription_form |> to_form()
-     )}
+      {:error, :not_found} ->
+        notify_to(
+          socket.assigns.notify_to,
+          socket.assigns.event_name,
+          {:flash, :error, "Subscription not found."}
+        )
+
+        {:noreply, socket}
+    end
   end
 
   @impl true
@@ -110,41 +122,49 @@ defmodule WandererAppWeb.Maps.MapSubscriptionsComponent do
         %{"id" => subscription_id} = _event,
         %{assigns: %{map_id: map_id}} = socket
       ) do
-    {:ok, _subscription} =
-      subscription_id
-      |> WandererApp.Api.MapSubscription.by_id!()
-      |> WandererApp.Api.MapSubscription.cancel()
+    with {:ok, subscription} <-
+           WandererAppWeb.HandlerAuth.authorize_subscription(subscription_id, map_id),
+         {:ok, _subscription} <- WandererApp.Api.MapSubscription.cancel(subscription) do
+      {:ok, map_subscriptions} = SubscriptionManager.get_map_subscriptions(map_id)
 
-    {:ok, map_subscriptions} = SubscriptionManager.get_map_subscriptions(map_id)
+      Phoenix.PubSub.broadcast(
+        WandererApp.PubSub,
+        "maps:#{map_id}",
+        {:subscription_settings_updated, map_id}
+      )
 
-    Phoenix.PubSub.broadcast(
-      WandererApp.PubSub,
-      "maps:#{map_id}",
-      {:subscription_settings_updated, map_id}
-    )
+      :telemetry.execute([:wanderer_app, :map, :subscription, :cancel], %{count: 1}, %{
+        map_id: map_id
+      })
 
-    :telemetry.execute([:wanderer_app, :map, :subscription, :cancel], %{count: 1}, %{
-      map_id: map_id
-    })
+      case LicenseManager.get_license_by_map_id(map_id) do
+        {:ok, license} ->
+          LicenseManager.invalidate_license(license.id)
+          Logger.info("Cancelled license for map #{map_id}")
 
-    case LicenseManager.get_license_by_map_id(map_id) do
-      {:ok, license} ->
-        LicenseManager.invalidate_license(license.id)
-        Logger.info("Cancelled license for map #{map_id}")
+        {:error, reason} ->
+          Logger.error("Failed to cancel license for map #{map_id}: #{inspect(reason)}")
+      end
 
-      {:error, reason} ->
-        Logger.error("Failed to cancel license for map #{map_id}: #{inspect(reason)}")
+      notify_to(
+        socket.assigns.notify_to,
+        socket.assigns.event_name,
+        {:flash, :info, "Subscription cancelled!"}
+      )
+
+      {:noreply,
+       socket
+       |> assign(is_adding_subscription?: false, map_subscriptions: map_subscriptions)}
+    else
+      _ ->
+        notify_to(
+          socket.assigns.notify_to,
+          socket.assigns.event_name,
+          {:flash, :error, "Subscription not found."}
+        )
+
+        {:noreply, socket}
     end
-
-    notify_to(
-      socket.assigns.notify_to,
-      socket.assigns.event_name,
-      {:flash, :info, "Subscription cancelled!"}
-    )
-
-    {:noreply,
-     socket
-     |> assign(is_adding_subscription?: false, map_subscriptions: map_subscriptions)}
   end
 
   @impl true
@@ -209,76 +229,89 @@ defmodule WandererAppWeb.Maps.MapSubscriptionsComponent do
         } = subscription_form,
         %{assigns: %{map_id: map_id, map: map, current_user: current_user}} = socket
       ) do
-    period = period |> String.to_integer()
-    promo_code = Map.get(subscription_form, "promo_code", "")
+    with {:ok, period} <- WandererAppWeb.HandlerAuth.parse_subscription_period(period),
+         {:ok, characters_limit} <-
+           WandererAppWeb.HandlerAuth.parse_characters_limit(characters_limit),
+         {:ok, hubs_limit} <- WandererAppWeb.HandlerAuth.parse_hubs_limit(hubs_limit) do
+      promo_code = Map.get(subscription_form, "promo_code", "")
 
-    {:ok, estimated_price, discount, _promo_valid?} =
-      WandererApp.Map.SubscriptionManager.estimate_price(subscription_form, false)
+      {:ok, estimated_price, discount, _promo_valid?} =
+        WandererApp.Map.SubscriptionManager.estimate_price(subscription_form, false)
 
-    active_till =
-      DateTime.utc_now()
-      |> DateTime.to_date()
-      |> Date.add(period * 30)
-      |> WandererApp.Map.SubscriptionManager.convert_date_to_datetime()
+      active_till =
+        DateTime.utc_now()
+        |> DateTime.to_date()
+        |> Date.add(period * 30)
+        |> WandererApp.Map.SubscriptionManager.convert_date_to_datetime()
 
-    {:ok, map_balance} = WandererApp.Map.SubscriptionManager.get_balance(map)
+      {:ok, map_balance} = WandererApp.Map.SubscriptionManager.get_balance(map)
 
-    case map_balance >= estimated_price - discount do
-      true ->
-        {:ok, _t} =
-          WandererApp.Api.MapTransaction.create(%{
+      case map_balance >= estimated_price - discount do
+        true ->
+          {:ok, _t} =
+            WandererApp.Api.MapTransaction.create(%{
+              map_id: map_id,
+              user_id: current_user.id,
+              amount: estimated_price - discount,
+              type: :out
+            })
+
+          {:ok, _sub} =
+            WandererApp.Api.MapSubscription.create(%{
+              map_id: map_id,
+              plan: :omega,
+              active_till: active_till,
+              characters_limit: characters_limit,
+              hubs_limit: hubs_limit,
+              auto_renew?: auto_renew?
+            })
+
+          {:ok, map_subscriptions} =
+            WandererApp.Map.SubscriptionManager.get_map_subscriptions(map_id)
+
+          Phoenix.PubSub.broadcast(
+            WandererApp.PubSub,
+            "maps:#{map_id}",
+            {:subscription_settings_updated, map_id}
+          )
+
+          :telemetry.execute([:wanderer_app, :map, :subscription, :new], %{count: 1}, %{
             map_id: map_id,
-            user_id: current_user.id,
             amount: estimated_price - discount,
-            type: :out
+            promo_code: if(promo_code != "", do: String.upcase(promo_code), else: nil)
           })
 
-        {:ok, _sub} =
-          WandererApp.Api.MapSubscription.create(%{
-            map_id: map_id,
-            plan: :omega,
-            active_till: active_till,
-            characters_limit: characters_limit |> String.to_integer(),
-            hubs_limit: hubs_limit |> String.to_integer(),
-            auto_renew?: auto_renew?
-          })
+          # Automatically create a license for the map
+          create_map_license(socket, map_id)
 
-        {:ok, map_subscriptions} =
-          WandererApp.Map.SubscriptionManager.get_map_subscriptions(map_id)
+          notify_to(
+            socket.assigns.notify_to,
+            socket.assigns.event_name,
+            {:flash, :info, "Subscription added!"}
+          )
 
-        Phoenix.PubSub.broadcast(
-          WandererApp.PubSub,
-          "maps:#{map_id}",
-          {:subscription_settings_updated, map_id}
-        )
+          {:noreply,
+           socket
+           |> assign(
+             is_adding_subscription?: false,
+             map_subscriptions: map_subscriptions
+           )}
 
-        :telemetry.execute([:wanderer_app, :map, :subscription, :new], %{count: 1}, %{
-          map_id: map_id,
-          amount: estimated_price - discount,
-          promo_code: if(promo_code != "", do: String.upcase(promo_code), else: nil)
-        })
+        _ ->
+          notify_to(
+            socket.assigns.notify_to,
+            socket.assigns.event_name,
+            {:flash, :error, "You have not enough ISK on Map Balance!"}
+          )
 
-        # Automatically create a license for the map
-        create_map_license(socket, map_id)
-
+          {:noreply, socket}
+      end
+    else
+      {:error, message} ->
         notify_to(
           socket.assigns.notify_to,
           socket.assigns.event_name,
-          {:flash, :info, "Subscription added!"}
-        )
-
-        {:noreply,
-         socket
-         |> assign(
-           is_adding_subscription?: false,
-           map_subscriptions: map_subscriptions
-         )}
-
-      _ ->
-        notify_to(
-          socket.assigns.notify_to,
-          socket.assigns.event_name,
-          {:flash, :error, "You have not enough ISK on Map Balance!"}
+          {:flash, :error, message}
         )
 
         {:noreply, socket}
@@ -302,102 +335,125 @@ defmodule WandererAppWeb.Maps.MapSubscriptionsComponent do
           }
         } = socket
       ) do
-    {:ok, additional_price, discount, _promo_valid?} =
-      WandererApp.Map.SubscriptionManager.calc_additional_price(
-        subscription_form,
-        selected_subscription
-      )
-
-    {:ok, map_balance} = WandererApp.Map.SubscriptionManager.get_balance(map)
-
-    case map_balance >= additional_price - discount do
-      true ->
-        {:ok, _t} =
-          WandererApp.Api.MapTransaction.create(%{
-            map_id: map_id,
-            user_id: current_user.id,
-            amount: additional_price - discount,
-            type: :out
-          })
-
-        {:ok, _} =
+    with true <- selected_subscription.map_id == map_id,
+         {:ok, characters_limit} <-
+           WandererAppWeb.HandlerAuth.parse_characters_limit(characters_limit),
+         {:ok, hubs_limit} <- WandererAppWeb.HandlerAuth.parse_hubs_limit(hubs_limit) do
+      {:ok, additional_price, discount, _promo_valid?} =
+        WandererApp.Map.SubscriptionManager.calc_additional_price(
+          subscription_form,
           selected_subscription
-          |> WandererApp.Api.MapSubscription.update_characters_limit!(%{
-            characters_limit: characters_limit |> String.to_integer()
-          })
-          |> WandererApp.Api.MapSubscription.update_hubs_limit!(%{
-            hubs_limit: hubs_limit |> String.to_integer()
-          })
-          |> WandererApp.Api.MapSubscription.update_auto_renew(%{auto_renew?: auto_renew?})
-
-        {:ok, map_subscriptions} =
-          WandererApp.Map.SubscriptionManager.get_map_subscriptions(map_id)
-
-        Phoenix.PubSub.broadcast(
-          WandererApp.PubSub,
-          "maps:#{map_id}",
-          {:subscription_settings_updated, map_id}
         )
 
-        :telemetry.execute([:wanderer_app, :map, :subscription, :update], %{count: 1}, %{
-          map_id: map_id,
-          amount: additional_price - discount
-        })
+      {:ok, map_balance} = WandererApp.Map.SubscriptionManager.get_balance(map)
 
-        # Check if a license exists, if not create one, otherwise update its expiration
-        # The License Manager service will verify the subscription is active
-        case LicenseManager.get_license_by_map_id(map_id) do
-          {:ok, _license} ->
-            # License exists, update its expiration date
-            case LicenseManager.update_license_expiration_from_subscription(map_id) do
-              {:ok, updated_license} ->
-                Logger.info(
-                  "Updated license expiration for map #{map_id} to #{updated_license.expire_at}"
-                )
+      case map_balance >= additional_price - discount do
+        true ->
+          {:ok, _t} =
+            WandererApp.Api.MapTransaction.create(%{
+              map_id: map_id,
+              user_id: current_user.id,
+              amount: additional_price - discount,
+              type: :out
+            })
 
-              {:error, "License not found"} ->
-                create_map_license(socket, map_id)
+          {:ok, _} =
+            selected_subscription
+            |> WandererApp.Api.MapSubscription.update_characters_limit!(%{
+              characters_limit: characters_limit
+            })
+            |> WandererApp.Api.MapSubscription.update_hubs_limit!(%{
+              hubs_limit: hubs_limit
+            })
+            |> WandererApp.Api.MapSubscription.update_auto_renew(%{auto_renew?: auto_renew?})
 
-              {:error, reason} ->
-                Logger.error(
-                  "Failed to update license expiration for map #{map_id}: #{inspect(reason)}"
-                )
+          {:ok, map_subscriptions} =
+            WandererApp.Map.SubscriptionManager.get_map_subscriptions(map_id)
 
-                notify_to(
-                  socket.assigns.notify_to,
-                  socket.assigns.event_name,
-                  {:flash, :error, "Failed to update license expiration for map #{map_id}!"}
-                )
-            end
+          Phoenix.PubSub.broadcast(
+            WandererApp.PubSub,
+            "maps:#{map_id}",
+            {:subscription_settings_updated, map_id}
+          )
 
-          {:error, :license_not_found} ->
-            # No license found, create one
-            create_map_license(socket, map_id)
+          :telemetry.execute([:wanderer_app, :map, :subscription, :update], %{count: 1}, %{
+            map_id: map_id,
+            amount: additional_price - discount
+          })
 
-          _ ->
-            # Error occurred, do nothing
-            :ok
-        end
+          # Check if a license exists, if not create one, otherwise update its expiration
+          # The License Manager service will verify the subscription is active
+          case LicenseManager.get_license_by_map_id(map_id) do
+            {:ok, _license} ->
+              # License exists, update its expiration date
+              case LicenseManager.update_license_expiration_from_subscription(map_id) do
+                {:ok, updated_license} ->
+                  Logger.info(
+                    "Updated license expiration for map #{map_id} to #{updated_license.expire_at}"
+                  )
 
+                {:error, "License not found"} ->
+                  create_map_license(socket, map_id)
+
+                {:error, reason} ->
+                  Logger.error(
+                    "Failed to update license expiration for map #{map_id}: #{inspect(reason)}"
+                  )
+
+                  notify_to(
+                    socket.assigns.notify_to,
+                    socket.assigns.event_name,
+                    {:flash, :error, "Failed to update license expiration for map #{map_id}!"}
+                  )
+              end
+
+            {:error, :license_not_found} ->
+              # No license found, create one
+              create_map_license(socket, map_id)
+
+            _ ->
+              # Error occurred, do nothing
+              :ok
+          end
+
+          notify_to(
+            socket.assigns.notify_to,
+            socket.assigns.event_name,
+            {:flash, :info, "Subscription updated!"}
+          )
+
+          {:noreply,
+           socket
+           |> assign(
+             is_adding_subscription?: false,
+             selected_subscription: nil,
+             map_subscriptions: map_subscriptions
+           )}
+
+        _ ->
+          notify_to(
+            socket.assigns.notify_to,
+            socket.assigns.event_name,
+            {:flash, :error, "You have not enough ISK on Map Balance!"}
+          )
+
+          {:noreply, socket}
+      end
+    else
+      {:error, message} ->
         notify_to(
           socket.assigns.notify_to,
           socket.assigns.event_name,
-          {:flash, :info, "Subscription updated!"}
+          {:flash, :error, message}
         )
 
-        {:noreply,
-         socket
-         |> assign(
-           is_adding_subscription?: false,
-           selected_subscription: nil,
-           map_subscriptions: map_subscriptions
-         )}
+        {:noreply, socket}
 
       _ ->
         notify_to(
           socket.assigns.notify_to,
           socket.assigns.event_name,
-          {:flash, :error, "You have not enough ISK on Map Balance!"}
+          {:flash, :error, "Subscription not found."}
         )
 
         {:noreply, socket}

--- a/test/wanderer_app_web/handler_auth_test.exs
+++ b/test/wanderer_app_web/handler_auth_test.exs
@@ -1,0 +1,308 @@
+defmodule WandererAppWeb.HandlerAuthTest do
+  @moduledoc """
+  Regression tests for the IDOR fixes in LiveView event handlers.
+
+  These tests cover `WandererAppWeb.HandlerAuth`, the small authorization
+  helper that the patched handlers now route client-supplied record IDs
+  through. Each helper must return `{:error, :not_found}` when a record
+  belongs to a different map (or user) than the one in the current LV scope.
+
+  See the PR description for the full list of handlers these protect.
+  """
+
+  use WandererApp.DataCase, async: false
+
+  alias WandererAppWeb.HandlerAuth
+
+  describe "authorize_subscription/2" do
+    setup do
+      user = create_user()
+      character_a = create_character(%{user_id: user.id})
+      character_b = create_character(%{user_id: user.id})
+      map_a = create_map(%{owner_id: character_a.id})
+      map_b = create_map(%{owner_id: character_b.id})
+
+      {:ok, subscription_a} =
+        Ash.create(WandererApp.Api.MapSubscription, %{
+          map_id: map_a.id,
+          plan: :omega,
+          characters_limit: 100,
+          hubs_limit: 10,
+          auto_renew?: true,
+          active_till: DateTime.utc_now() |> DateTime.add(30, :day)
+        })
+
+      {:ok, map_a: map_a, map_b: map_b, subscription_a: subscription_a}
+    end
+
+    test "returns {:ok, sub} when subscription belongs to the given map", %{
+      map_a: map_a,
+      subscription_a: subscription_a
+    } do
+      assert {:ok, returned} = HandlerAuth.authorize_subscription(subscription_a.id, map_a.id)
+      assert returned.id == subscription_a.id
+    end
+
+    test "returns {:error, :not_found} when subscription is on a different map", %{
+      map_b: map_b,
+      subscription_a: subscription_a
+    } do
+      # The classic IDOR repro: pass map_a's subscription id while scoped to map_b.
+      assert {:error, :not_found} =
+               HandlerAuth.authorize_subscription(subscription_a.id, map_b.id)
+    end
+
+    test "returns {:error, :not_found} for a nonexistent subscription id", %{map_a: map_a} do
+      assert {:error, :not_found} =
+               HandlerAuth.authorize_subscription(Ecto.UUID.generate(), map_a.id)
+    end
+  end
+
+  describe "authorize_character/2" do
+    setup do
+      user_a = create_user()
+      user_b = create_user()
+      character_a = create_character(%{user_id: user_a.id})
+
+      {:ok, user_a: user_a, user_b: user_b, character_a: character_a}
+    end
+
+    test "returns {:ok, char} when character is owned by the given user", %{
+      user_a: user_a,
+      character_a: character_a
+    } do
+      assert {:ok, returned} = HandlerAuth.authorize_character(character_a.id, user_a.id)
+      assert returned.id == character_a.id
+    end
+
+    test "returns {:error, :not_found} when character belongs to a different user", %{
+      user_b: user_b,
+      character_a: character_a
+    } do
+      # Repro for characters_live.ex "delete": user B pushes user A's character_id.
+      assert {:error, :not_found} = HandlerAuth.authorize_character(character_a.id, user_b.id)
+    end
+
+    test "returns {:error, :not_found} for a nonexistent character id", %{user_a: user_a} do
+      assert {:error, :not_found} =
+               HandlerAuth.authorize_character(Ecto.UUID.generate(), user_a.id)
+    end
+  end
+
+  describe "authorize_ping/2" do
+    setup do
+      user = create_user()
+      character_a = create_character(%{user_id: user.id})
+      character_b = create_character(%{user_id: user.id})
+      map_a = create_map(%{owner_id: character_a.id})
+      map_b = create_map(%{owner_id: character_b.id})
+
+      system_a =
+        create_map_system(map_a.id, %{solar_system_id: 30_000_142, position_x: 0, position_y: 0})
+
+      {:ok, ping_a} =
+        Ash.create(WandererApp.Api.MapPing, %{
+          map_id: map_a.id,
+          system_id: system_a.id,
+          character_id: character_a.id,
+          type: 0,
+          message: "test"
+        })
+
+      {:ok, map_a: map_a, map_b: map_b, ping_a: ping_a}
+    end
+
+    test "returns {:ok, ping} when ping belongs to the given map", %{
+      map_a: map_a,
+      ping_a: ping_a
+    } do
+      assert {:ok, returned} = HandlerAuth.authorize_ping(ping_a.id, map_a.id)
+      assert returned.id == ping_a.id
+    end
+
+    test "returns {:error, :not_found} when ping is on a different map", %{
+      map_b: map_b,
+      ping_a: ping_a
+    } do
+      # Repro for cancel_ping cross-map cancellation.
+      assert {:error, :not_found} = HandlerAuth.authorize_ping(ping_a.id, map_b.id)
+    end
+  end
+
+  describe "authorize_system_comment/2" do
+    setup do
+      user = create_user()
+      character_a = create_character(%{user_id: user.id})
+      character_b = create_character(%{user_id: user.id})
+      map_a = create_map(%{owner_id: character_a.id})
+      map_b = create_map(%{owner_id: character_b.id})
+
+      system_a =
+        create_map_system(map_a.id, %{solar_system_id: 30_000_142, position_x: 0, position_y: 0})
+
+      {:ok, comment_a} =
+        Ash.create(WandererApp.Api.MapSystemComment, %{
+          system_id: system_a.id,
+          character_id: character_a.id,
+          text: "hi"
+        })
+
+      {:ok, map_a: map_a, map_b: map_b, comment_a: comment_a}
+    end
+
+    test "returns {:ok, comment} when comment's system belongs to the given map", %{
+      map_a: map_a,
+      comment_a: comment_a
+    } do
+      assert {:ok, returned} = HandlerAuth.authorize_system_comment(comment_a.id, map_a.id)
+      assert returned.id == comment_a.id
+    end
+
+    test "returns {:error, :not_found} when comment's system is on a different map", %{
+      map_b: map_b,
+      comment_a: comment_a
+    } do
+      # Repro for deleteSystemComment cross-map deletion.
+      assert {:error, :not_found} =
+               HandlerAuth.authorize_system_comment(comment_a.id, map_b.id)
+    end
+  end
+
+  describe "authorize_passage/2" do
+    setup do
+      user = create_user()
+      character_a = create_character(%{user_id: user.id})
+      character_b = create_character(%{user_id: user.id})
+      map_a = create_map(%{owner_id: character_a.id})
+      map_b = create_map(%{owner_id: character_b.id})
+
+      {:ok, passage_a} =
+        Ash.create(WandererApp.Api.MapChainPassages, %{
+          map_id: map_a.id,
+          character_id: character_a.id,
+          ship_type_id: 587,
+          ship_name: "Rifter",
+          mass: 1_000_000,
+          solar_system_source_id: 30_000_142,
+          solar_system_target_id: 30_000_144
+        })
+
+      {:ok, map_a: map_a, map_b: map_b, passage_a: passage_a}
+    end
+
+    test "returns {:ok, passage} when passage belongs to the given map", %{
+      map_a: map_a,
+      passage_a: passage_a
+    } do
+      assert {:ok, returned} = HandlerAuth.authorize_passage(passage_a.id, map_a.id)
+      assert returned.id == passage_a.id
+    end
+
+    test "returns {:error, :not_found} when passage is on a different map", %{
+      map_b: map_b,
+      passage_a: passage_a
+    } do
+      # Repro for update_passage_mass cross-map corruption.
+      assert {:error, :not_found} = HandlerAuth.authorize_passage(passage_a.id, map_b.id)
+    end
+  end
+
+  describe "user_owns_character_eve_id?/2" do
+    test "returns true when eve_id (as integer) matches a character in the list" do
+      characters = [%{eve_id: "100"}, %{eve_id: "200"}]
+      assert HandlerAuth.user_owns_character_eve_id?(characters, 100)
+    end
+
+    test "returns true when eve_id (as string) matches a character in the list" do
+      characters = [%{eve_id: "100"}, %{eve_id: "200"}]
+      assert HandlerAuth.user_owns_character_eve_id?(characters, "200")
+    end
+
+    test "returns false when eve_id does not match any character" do
+      # Repro for updateCharacterTracking attempting to untrack someone else's char.
+      characters = [%{eve_id: "100"}, %{eve_id: "200"}]
+      refute HandlerAuth.user_owns_character_eve_id?(characters, "999")
+    end
+
+    test "returns false for empty character list" do
+      refute HandlerAuth.user_owns_character_eve_id?([], "100")
+    end
+  end
+
+  describe "parse_subscription_period/1" do
+    test "accepts the form's allowed periods" do
+      assert {:ok, 1} = HandlerAuth.parse_subscription_period("1")
+      assert {:ok, 3} = HandlerAuth.parse_subscription_period("3")
+      assert {:ok, 6} = HandlerAuth.parse_subscription_period("6")
+      assert {:ok, 12} = HandlerAuth.parse_subscription_period("12")
+    end
+
+    test "rejects negative period (subscribe exploit)" do
+      # Repro for the negative-period subscription exploit: `period: "-1"`
+      # previously produced a back-dated `active_till` and flipped the
+      # `estimated_price * period` calculation to a negative number.
+      assert {:error, _} = HandlerAuth.parse_subscription_period("-1")
+      assert {:error, _} = HandlerAuth.parse_subscription_period("-12")
+    end
+
+    test "rejects zero, out-of-range, and trailing-garbage values" do
+      assert {:error, _} = HandlerAuth.parse_subscription_period("0")
+      assert {:error, _} = HandlerAuth.parse_subscription_period("2")
+      assert {:error, _} = HandlerAuth.parse_subscription_period("24")
+      assert {:error, _} = HandlerAuth.parse_subscription_period("999999999")
+      assert {:error, _} = HandlerAuth.parse_subscription_period("12x")
+      assert {:error, _} = HandlerAuth.parse_subscription_period("abc")
+      assert {:error, _} = HandlerAuth.parse_subscription_period("")
+    end
+
+    test "rejects non-binary input without raising" do
+      # The pre-fix handler called `String.to_integer` on raw client input
+      # and crashed the LV process on a non-binary. The parser must accept
+      # whatever the client sends.
+      assert {:error, _} = HandlerAuth.parse_subscription_period(nil)
+      assert {:error, _} = HandlerAuth.parse_subscription_period(1)
+      assert {:error, _} = HandlerAuth.parse_subscription_period(%{})
+    end
+  end
+
+  describe "parse_characters_limit/1" do
+    test "accepts values in the form's allowed range (50..5000)" do
+      assert {:ok, 50} = HandlerAuth.parse_characters_limit("50")
+      assert {:ok, 5_000} = HandlerAuth.parse_characters_limit("5000")
+      assert {:ok, 250} = HandlerAuth.parse_characters_limit(250)
+    end
+
+    test "rejects values outside the allowed range" do
+      assert {:error, _} = HandlerAuth.parse_characters_limit("0")
+      assert {:error, _} = HandlerAuth.parse_characters_limit("49")
+      assert {:error, _} = HandlerAuth.parse_characters_limit("5001")
+      assert {:error, _} = HandlerAuth.parse_characters_limit("999999999999")
+      assert {:error, _} = HandlerAuth.parse_characters_limit("-50")
+    end
+
+    test "rejects malformed input without raising" do
+      assert {:error, _} = HandlerAuth.parse_characters_limit("abc")
+      assert {:error, _} = HandlerAuth.parse_characters_limit("")
+      assert {:error, _} = HandlerAuth.parse_characters_limit(nil)
+    end
+  end
+
+  describe "parse_hubs_limit/1" do
+    test "accepts values in the form's allowed range (20..50)" do
+      assert {:ok, 20} = HandlerAuth.parse_hubs_limit("20")
+      assert {:ok, 50} = HandlerAuth.parse_hubs_limit("50")
+    end
+
+    test "rejects values outside the allowed range" do
+      assert {:error, _} = HandlerAuth.parse_hubs_limit("19")
+      assert {:error, _} = HandlerAuth.parse_hubs_limit("51")
+      assert {:error, _} = HandlerAuth.parse_hubs_limit("0")
+      assert {:error, _} = HandlerAuth.parse_hubs_limit("-5")
+    end
+
+    test "rejects malformed input without raising" do
+      assert {:error, _} = HandlerAuth.parse_hubs_limit("abc")
+      assert {:error, _} = HandlerAuth.parse_hubs_limit(nil)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Audit + fix for a class of authorization bugs in LiveView event handlers, prompted by a user-reported negative-amount injection in the map balance topup flow (patched separately on `guarzo/balancefix`).


### The pattern

Every fix shares the same shape: a `handle_event` callback accepted a record UUID from `phx-value-id` (or similar) and acted on the record without checking it belongs to the user's current map/user scope. A logged-in user can submit any UUID over the LV socket — the form's hidden inputs and disabled buttons mean nothing on the wire.

### Fixes

| Handler | Before | After |
|---|---|---|
| `cancel-subscription` | Any logged-in user could cancel any map's paid subscription by ID | Verifies `subscription.map_id == socket.assigns.map_id` |
| `edit-subscription` / `update_subscription` | Same shape, plus could charge map A's balance to upgrade map B's sub | Same map_id check |
| `subscribe` / `update_subscription` (period/limits) | `period: "-1"` produced free, back-dated subscriptions; `characters_limit`/`hubs_limit` were unbounded | Allow-list parsing against the form's actual ranges |
| `characters_live.ex "delete"` | Any user could soft-delete any character and null their `user_id` | Verifies `character.user_id == socket.assigns.user_id` |
| `cancel_ping` | Cross-map rally-ping cancellation broadcast | Verifies ping belongs to current map |
| `deleteSystemComment` | Cross-map comment deletion | Verifies comment's system belongs to current map |
| `update_passage_mass` | Cross-map wormhole passage mass corruption | Verifies passage belongs to current map |
| `updateCharacterTracking` | Could untrack another user's character on a shared map | Verifies eve_id is in `current_user.characters` |

### Approach

Added a small `WandererAppWeb.HandlerAuth` module with focused `authorize_*` and `parse_*` helpers. Each LV handler now routes its client-supplied ID through one of these helpers and returns a generic ``"not found"`` flash on failure (we deliberately don't distinguish ``"doesn't exist"`` from ``"exists on another map"`` to avoid leaking the existence of records in other contexts).

Discussed and chose **handler-level fixes** over **resource-level Ash policies** for this PR — smaller diff, visible at the trust boundary, easy to review. Pushing checks into Ash policies on `MapSubscription`, `MapChainPassages`, `MapPings`, `MapSystemComment`, and `Character` is the right long-term hardening and worth a follow-up ticket.


## Test plan
- [x] Unit tests: 26 new tests in `test/wanderer_app_web/handler_auth_test.exs` cover all 5 `authorize_*` helpers (happy path + cross-scope IDOR repro + nonexistent ID) and all 3 `parse_*` helpers (allow-list + negative + out-of-range + malformed + non-binary)
- [x] All 26 pass: `mix test test/wanderer_app_web/handler_auth_test.exs`
- [x] Full suite: 926 tests, 13 pre-existing failures (map_duplication / auth_controller / map_scopes — verified by re-running on bare `main`, unrelated to this PR)
- [x] `mix compile` clean (no new warnings)
- [x] `mix format` applied
- [ ] Smoke-test in dev: open Map A as user B, try the form actions that previously leaked across maps
- [ ] Consider DB audit on prod for historical cross-map abuse: any `MapSubscription` with `status = :cancelled` where the cancelling user's UUID doesn't own the map; any orphan `Character` rows with `user_id IS NULL` and `deleted = true`

