### PR TITLE
Recoverable crash on update location with debug logs on

### DIFF
--- a/lib/wanderer_app/map/server/map_server_characters_impl.ex
+++ b/lib/wanderer_app/map/server/map_server_characters_impl.ex
@@ -934,8 +934,8 @@ defmodule WandererApp.Map.Server.CharactersImpl do
     Logger.debug(
       "[CharacterTracking] update_location: map=#{map_id}, " <>
         "from=#{old_location.solar_system_id}, to=#{location.solar_system_id}, " <>
-        "scopes=#{inspect(scopes)}, map.scopes=#{inspect(map[:scopes])}, " <>
-        "map.scope=#{inspect(map[:scope])}, is_valid=#{is_valid}"
+        "scopes=#{inspect(scopes)}, map.scopes=#{inspect(map.scopes)}, " <>
+        "map.scope=#{inspect(map.scope)}, is_valid=#{is_valid}"
     )
 
     case is_valid do


### PR DESCRIPTION
Whenever you enable debug level on logs and Wanderer calls the `update_location`, because of it's trying to access the struct attributes as `map[:scopes]`, it's crashing but then recovers. But the side effects of this function not working as intended are:

- New systems/connections aren't created as your character moves around.
- Because of previous point, the dialog that should appear when it makes you pick the signature to link with the connection, doesn't.
- The mass that passed through isn't inserted into the connection

There could be other features that depend on `update_location` working, but I haven't found them.

This PR fixes it by accessing the struct attributes using one of the ways that they should be accessed with, ex: `map.scopes`.

The error you get when the log tries to get written is as follow. It's larger than shown below, cause it prints the struct contents but I reduced it into just `[[-- INSERT STRUCT ATTRIBUTES HERE --]]`:

```
17:04:33.811 [error] Task #PID<0.5191.0> started from :"Elixir.WandererApp.Map.MapPool.8036a3c4-64ed-11f1-99bc-ca569e9676da" terminating
** (UndefinedFunctionError) function WandererApp.Map.fetch/2 is undefined (WandererApp.Map does not implement the Access behaviour

You can use the "struct.field" syntax to access struct fields. You can also use Access.key!/1 to access struct fields dynamically inside get_in/put_in/update_in)
    (wanderer_app 1.101.1) WandererApp.Map.fetch(%WandererApp.Map{ [[-- INSERT STRUCT ATTRIBUTES HERE --]] }, :scopes)
    (elixir 1.17.3) lib/access.ex:322: Access.get/3
    (wanderer_app 1.101.1) lib/wanderer_app/map/server/map_server_characters_impl.ex:937: WandererApp.Map.Server.CharactersImpl.update_location/4
    (wanderer_app 1.101.1) lib/wanderer_app/map/server/map_server_characters_impl.ex:615: anonymous fn/3 in WandererApp.Map.Server.CharactersImpl.process_character_changes/5
    (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (wanderer_app 1.101.1) lib/wanderer_app/map/server/map_server_characters_impl.ex:597: WandererApp.Map.Server.CharactersImpl.process_character_changes/5
    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4
Function: &:erlang.apply/2
    Args: [#Function<29.66530767/1 in WandererApp.Map.Server.CharactersImpl.update_characters/1>, ["5965775b-ad2e-4335-ab40-c8c198ba091d"]]
17:04:33.875 application=wanderer_app module=WandererApp.Map.MapPool function=init/1 line=71 [info] [Map Pool 8036a3c4-64ed-11f1-99bc-ca569e9676da] Crash recovery detected: recovering 1 maps
17:04:33.875 application=wanderer_app module=WandererApp.Map.MapPool function=handle_continue/2 line=141 [info] Elixir.WandererApp.Map.MapPool started
17:04:33.876 application=wanderer_app module=WandererApp.Map.MapPoolState function=save_pool_state/2 line=61 [debug] Saved MapPool state for 8036a3c4-64ed-11f1-99bc-ca569e9676da: 1 maps
17:04:33.876 application=wanderer_app module=WandererApp.Map.MapPool function=do_start_map/2 line=376 [debug] [Map Pool] Successfully started map 0f0ebb99-2fb4-4c76-898f-609ff8acd932 in pool 8036a3c4-64ed-11f1-99bc-ca569e9676da
17:04:33.876 application=wanderer_app module=WandererApp.Map.MapPool function=handle_continue/2 line=179 [info] [Map Pool 8036a3c4-64ed-11f1-99bc-ca569e9676da] Crash recovery completed: 1/1 maps recovered in 1ms
```