### PR TITLE
fix(core): Shattered J015092 has the wrong statics

### DIFF
--- a/priv/repo/data/wormholeSystems.json
+++ b/priv/repo/data/wormholeSystems.json
@@ -33102,7 +33102,7 @@
 		"solarSystemID": 31002505,
 		"statics": [
 			"N110",
-			"J244"
+			"Z060"
 		],
 		"systemName": "J015092",
 		"effectName": "Black Hole"


### PR DESCRIPTION
fix(core): Shattered J015092 has the wrong statics: - changed from J244 (LS) static - to N110 (HS)