### PR TITLE
fix(mapper): Preserve intentional leading spaces in bookmark name formats

### DIFF
--- a/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
+++ b/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
@@ -357,7 +357,18 @@ export const formatBookmarkName = (
   result = result.replace(/\{description\}/g, () => signature.description || '');
 
   // Cleanup whitespace
-  return result.trim().replace(/\s+/g, ' ');
+  if (/^\s*$/.test(formatStr)) {
+    return formatStr;
+  }
+
+  const leadingSpaces = formatStr.match(/^\s+/)?.[0] || '';
+  const cleaned = result.trim().replace(/\s+/g, ' ');
+
+  if (cleaned === '') {
+    return leadingSpaces;
+  }
+
+  return `${leadingSpaces}${cleaned}`;
 };
 
 export const copyToClipboard = async (text: string) => {


### PR DESCRIPTION
**Overview**
Fixes an issue where intentional leading spaces in custom bookmark name formats were being unintentionally pruned during the whitespace cleanup phase. 

**The Problem**
Previously, when formatting bookmark names, the final string was passed through `.trim().replace(/\s+/g, ' ')`. This was intended to clean up double spaces left behind by variables that evaluated to empty strings. However, the `.trim()` call would completely strip any deliberate leading spaces the user configured in their `bookmark_name_format` setting (e.g., `" {dest_type} {sig_letters} {temporary_name}"` would output `"HS ABC TEMP"` instead of `" HS ABC TEMP"`).

**The Solution**
This MR updates the whitespace cleanup logic in `bookmarkFormatHelper.ts` to:
1. Extract any exact leading spaces directly from the user's original `formatStr` template.
2. Run the normal `.trim().replace(/\s+/g, ' ')` cleanup on the evaluated output to safely consolidate interior spacing gaps from empty variables.
3. Prepend the user's intentional leading spaces back onto the cleaned string before returning it. 

Note: Trailing spaces are purposefully not preserved as they are generally undesirable and prone to accidental inclusion.