### PR TITLE
feat: autofocus on signature descryption field when doubleclicked/editing

### DIFF
--- a/assets/js/hooks/Mapper/components/mapInterface/components/SystemCustomLabelDialog/SystemCustomLabelDialog.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/components/SystemCustomLabelDialog/SystemCustomLabelDialog.tsx
@@ -114,7 +114,7 @@ export const SystemCustomLabelDialog = ({ systemId, visible, setVisible }: Syste
                   aria-describedby="username-help"
                   autoComplete="off"
                   value={label}
-                  maxLength={5}
+                  maxLength={11}
                   onChange={e => setLabel(e.target.value)}
                   // @ts-expect-error
                   ref={inputRef}

--- a/assets/js/hooks/Mapper/components/mapInterface/components/SystemSettingsDialog/SystemSettingsDialog.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/components/SystemSettingsDialog/SystemSettingsDialog.tsx
@@ -176,7 +176,7 @@ export const SystemSettingsDialog = ({ systemId, visible, setVisible }: SystemSe
                   aria-describedby="label"
                   autoComplete="off"
                   value={label}
-                  maxLength={5}
+                  maxLength={11}
                   onChange={e => setLabel(e.target.value)}
                   onInput={handleInput}
                 />

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/SignatureSettings.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/SignatureSettings.tsx
@@ -11,8 +11,8 @@ import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
 import { MassState, OutCommand, SignatureGroup, SystemSignature, TimeStatus } from '@/hooks/Mapper/types';
 import { Dialog } from 'primereact/dialog';
 import { InputText } from 'primereact/inputtext';
-import { useCallback, useEffect, useState } from 'react';
-import { Controller, FormProvider, useForm } from 'react-hook-form';
+import { useCallback, useEffect, useState, inputRef} from 'react';
+import { Controller, FormProvider, useForm, useRef } from 'react-hook-form';
 
 type SystemSignaturePrepared = Omit<SystemSignature, 'linked_system'> & {
   linked_system: string;
@@ -35,9 +35,15 @@ export const SignatureSettings = ({ systemId, show, onHide, signatureData }: Map
     data: { systemSignatures, systems, wormholesData },
   } = useMapRootState();
 
-  const handleShow = async () => {};
-
   const signatureForm = useForm<Partial<SystemSignaturePrepared>>({});
+
+  const { setFocus } = signatureForm;
+
+ const handleShow = useCallback(() => {
+  setTimeout(() => {
+    setFocus("description");
+  }, 60);
+}, [setFocus]);
 
   const [userSettings, setUserSettings] = useState<any>(null);
 
@@ -266,7 +272,7 @@ export const SignatureSettings = ({ systemId, show, onHide, signatureData }: Map
                     name="description"
                     control={signatureForm.control}
                     render={({ field }) => (
-                      <InputText placeholder="Type description" value={field.value} onChange={field.onChange} />
+                      <InputText placeholder="Type description" ref ={field.ref} value={field.value} onChange={field.onChange} />
                     )}
                   />
                 </label>

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/SignatureSettings.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/SignatureSettings.tsx
@@ -11,8 +11,8 @@ import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
 import { MassState, OutCommand, SignatureGroup, SystemSignature, TimeStatus } from '@/hooks/Mapper/types';
 import { Dialog } from 'primereact/dialog';
 import { InputText } from 'primereact/inputtext';
-import { useCallback, useEffect, useState, inputRef} from 'react';
-import { Controller, FormProvider, useForm, useRef } from 'react-hook-form';
+import { useCallback, useEffect, useState} from 'react';
+import { Controller, FormProvider, useForm} from 'react-hook-form';
 
 type SystemSignaturePrepared = Omit<SystemSignature, 'linked_system'> & {
   linked_system: string;
@@ -39,10 +39,8 @@ export const SignatureSettings = ({ systemId, show, onHide, signatureData }: Map
 
   const { setFocus } = signatureForm;
 
- const handleShow = useCallback(() => {
-  setTimeout(() => {
+  const handleShow = useCallback(() => {
     setFocus("description");
-  }, 60);
 }, [setFocus]);
 
   const [userSettings, setUserSettings] = useState<any>(null);
@@ -272,7 +270,7 @@ export const SignatureSettings = ({ systemId, show, onHide, signatureData }: Map
                     name="description"
                     control={signatureForm.control}
                     render={({ field }) => (
-                      <InputText placeholder="Type description" ref ={field.ref} value={field.value} onChange={field.onChange} />
+                      <InputText placeholder="Type description" ref={field.ref} value={field.value} onChange={field.onChange} />
                     )}
                   />
                 </label>


### PR DESCRIPTION
small quality of life change: when doubleclicking/editing pasted signature "type descryption" is automaticaly focused and ready to receive keyboard input 
(1 less click required - based on system settings windows when doubleclicking system on the map)

edit: oj i gues i dont know how to use git properly yet so it goes into same pull-request i gues:
also increased limit for custom label to 11 characters hear me out - i tried to break the interface and you literaly have to have ALL the label thingies up for it to start poping out to the right side of the system. i think having few more characters to use will outweight that one edge-case.