### PR TITLE
Include characters that haven't passaged in user activity API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDER_IMAGE="wandererltd/build-base:latest"
 ARG RUNNER_IMAGE="wandererltd/runner-base:latest"
 
-FROM ${BUILDER_IMAGE} as builder
+FROM ${BUILDER_IMAGE} AS builder
 
 # prepare build dir
 WORKDIR /app

--- a/lib/wanderer_app/map.ex
+++ b/lib/wanderer_app/map.ex
@@ -715,39 +715,49 @@ defmodule WandererApp.Map do
 
   @doc """
   Returns the raw activity data that can be processed by WandererApp.Character.Activity.
-  Only includes characters that are on the map's ACL.
+  Includes every character with any recorded activity on the map (passages,
+  connections, or signatures), not only those who have passages.
   If days parameter is provided, filters activity to that time period.
   """
   def get_character_activity(map_id, days \\ nil) do
-    with {:ok, map} <- WandererApp.Api.Map.by_id(map_id) do
-      _map_with_acls = Ash.load!(map, :acls)
-
+    with {:ok, _map} <- WandererApp.Api.Map.by_id(map_id) do
       # Calculate cutoff date if days is provided
       cutoff_date =
         if days, do: DateTime.utc_now() |> DateTime.add(-days * 24 * 3600, :second), else: nil
 
-      # Get activity data
-      passages_activity = get_passages_activity(map_id, cutoff_date)
-      connections_activity = get_connections_activity(map_id, cutoff_date)
-      signatures_activity = get_signatures_activity(map_id, cutoff_date)
+      # Each helper returns a list of {character, count} tuples.
+      passages = get_passages_activity(map_id, cutoff_date)
+      connections = get_connections_activity(map_id, cutoff_date)
+      signatures = get_signatures_activity(map_id, cutoff_date)
 
-      # Return activity data
+      passages_counts = counts_by_character(passages)
+      connections_counts = counts_by_character(connections)
+      signatures_counts = counts_by_character(signatures)
+
+      # Build the result from the UNION of all characters with any activity, so a
+      # contributor is never dropped just because they have no passages.
       result =
-        passages_activity
-        |> Enum.map(fn passage ->
+        (passages ++ connections ++ signatures)
+        |> Enum.map(fn {character, _count} -> {character.id, character} end)
+        |> Map.new()
+        |> Enum.map(fn {character_id, character} ->
           %{
-            character: passage.character,
-            passages: passage.count,
-            connections: Map.get(connections_activity, passage.character.id, 0),
-            signatures: Map.get(signatures_activity, passage.character.id, 0),
+            character: character,
+            passages: Map.get(passages_counts, character_id, 0),
+            connections: Map.get(connections_counts, character_id, 0),
+            signatures: Map.get(signatures_counts, character_id, 0),
             timestamp: DateTime.utc_now(),
-            character_id: passage.character.id,
-            user_id: passage.character.user_id
+            character_id: character_id,
+            user_id: character.user_id
           }
         end)
 
       {:ok, result}
     end
+  end
+
+  defp counts_by_character(entries) do
+    Map.new(entries, fn {character, count} -> {character.id, count} end)
   end
 
   defp get_passages_activity(map_id, nil) do
@@ -759,7 +769,6 @@ defmodule WandererApp.Map do
       select: {c, count(p.id)}
     )
     |> WandererApp.Repo.all()
-    |> Enum.map(fn {character, count} -> %{character: character, count: count} end)
   end
 
   defp get_passages_activity(map_id, cutoff_date) do
@@ -773,7 +782,6 @@ defmodule WandererApp.Map do
       select: {c, count(p.id)}
     )
     |> WandererApp.Repo.all()
-    |> Enum.map(fn {character, count} -> %{character: character, count: count} end)
   end
 
   defp get_connections_activity(map_id, nil) do
@@ -785,10 +793,9 @@ defmodule WandererApp.Map do
           ua.entity_type == :map and
           ua.event_type == :map_connection_added,
       group_by: [c.id],
-      select: {c.id, count(ua.id)}
+      select: {c, count(ua.id)}
     )
     |> WandererApp.Repo.all()
-    |> Map.new()
   end
 
   defp get_connections_activity(map_id, cutoff_date) do
@@ -800,10 +807,9 @@ defmodule WandererApp.Map do
           ua.event_type == :map_connection_added and
           ua.inserted_at > ^cutoff_date,
       group_by: [c.id],
-      select: {c.id, count(ua.id)}
+      select: {c, count(ua.id)}
     )
     |> WandererApp.Repo.all()
-    |> Map.new()
   end
 
   defp get_signatures_activity(map_id, nil) do
@@ -814,7 +820,7 @@ defmodule WandererApp.Map do
         ua.entity_id == ^map_id and
           ua.entity_type == :map and
           ua.event_type == :signatures_added,
-      select: {ua.character_id, ua.event_data}
+      select: {c, ua.event_data}
     )
     |> WandererApp.Repo.all()
     |> process_signatures_data()
@@ -828,7 +834,7 @@ defmodule WandererApp.Map do
           ua.entity_type == :map and
           ua.event_type == :signatures_added and
           ua.inserted_at > ^cutoff_date,
-      select: {ua.character_id, ua.event_data}
+      select: {c, ua.event_data}
     )
     |> WandererApp.Repo.all()
     |> process_signatures_data()
@@ -836,14 +842,13 @@ defmodule WandererApp.Map do
 
   defp process_signatures_data(signatures_data) do
     signatures_data
-    |> Enum.group_by(fn {character_id, _} -> character_id end)
-    |> Enum.map(&process_character_signatures/1)
-    |> Map.new()
+    |> Enum.group_by(fn {character, _} -> character.id end)
+    |> Enum.map(fn {_id, entries} -> process_character_signatures(entries) end)
   end
 
-  defp process_character_signatures({character_id, activities}) do
+  defp process_character_signatures([{character, _} | _] = entries) do
     signature_count =
-      activities
+      entries
       |> Enum.map(fn {_, event_data} ->
         case Jason.decode(event_data) do
           {:ok, data} -> length(Map.get(data, "signatures", []))
@@ -852,6 +857,6 @@ defmodule WandererApp.Map do
       end)
       |> Enum.sum()
 
-    {character_id, signature_count}
+    {character, signature_count}
   end
 end

--- a/lib/wanderer_app/map/operations/connections.ex
+++ b/lib/wanderer_app/map/operations/connections.ex
@@ -22,9 +22,7 @@ defmodule WandererApp.Map.Operations.Connections do
 
   # System class constants
   @c1_system_class 1
-  @c4_system_class 4
   @c13_system_class 13
-  @ns_system_class 9
 
   @doc """
   Creates a connection between two systems, applying special rules for C1, C13, and C4 wormholes.

--- a/lib/wanderer_app/map/server/map_server_connections_impl.ex
+++ b/lib/wanderer_app/map/server/map_server_connections_impl.ex
@@ -213,7 +213,7 @@ defmodule WandererApp.Map.Server.ConnectionsImpl do
       solar_system_target_id
     )
     |> case do
-      {:ok, %{id: connection_id} = connection} ->
+      {:ok, %{id: connection_id}} ->
         connection_mark_eol_time = get_connection_mark_eol_time(map_id, connection_id, nil)
         locked_info = get_connection_locked_info(map_id, connection_id)
 

--- a/lib/wanderer_app_web.ex
+++ b/lib/wanderer_app_web.ex
@@ -46,7 +46,7 @@ defmodule WandererAppWeb do
 
       import Phoenix.LiveView.Controller
       import Plug.Conn
-      import WandererAppWeb.Gettext
+      use Gettext, backend: WandererAppWeb.Gettext
 
       unquote(verified_routes())
     end
@@ -102,7 +102,7 @@ defmodule WandererAppWeb do
       import Phoenix.HTML
       # Core UI components and translation
       import WandererAppWeb.CoreComponents
-      import WandererAppWeb.Gettext
+      use Gettext, backend: WandererAppWeb.Gettext
       import WandererAppWeb.Helpers.CSP
 
       # Shortcut for generating JS commands

--- a/lib/wanderer_app_web/components/core_components.ex
+++ b/lib/wanderer_app_web/components/core_components.ex
@@ -17,7 +17,7 @@ defmodule WandererAppWeb.CoreComponents do
   use Phoenix.Component
 
   alias Phoenix.LiveView.JS
-  import WandererAppWeb.Gettext
+  use Gettext, backend: WandererAppWeb.Gettext
 
   @image_base_url "https://images.evetech.net"
 

--- a/lib/wanderer_app_web/controllers/map_audit_api_controller.ex
+++ b/lib/wanderer_app_web/controllers/map_audit_api_controller.ex
@@ -154,10 +154,10 @@ defmodule WandererAppWeb.MapAuditAPIController do
 
     result
     |> Map.put(:character, WandererAppWeb.MapEventHandler.map_ui_character_stat(character))
-    |> Map.put(:event_name, WandererAppWeb.UserActivityItem.get_event_name(event_type))
+    |> Map.put(:event_name, UserActivityItem.get_event_name(event_type))
     |> Map.put(
       :event_data,
-      WandererAppWeb.UserActivityItem.get_event_data(
+      UserActivityItem.get_event_data(
         event_type,
         Jason.decode!(event_data) |> Map.drop(["character_id"])
       )

--- a/lib/wanderer_app_web/gettext.ex
+++ b/lib/wanderer_app_web/gettext.ex
@@ -5,7 +5,7 @@ defmodule WandererAppWeb.Gettext do
   By using [Gettext](https://hexdocs.pm/gettext),
   your module gains a set of macros for translations, for example:
 
-      import WandererAppWeb.Gettext
+      use Gettext, backend: WandererAppWeb.Gettext
 
       # Simple translation
       gettext("Here is the string to translate")
@@ -20,5 +20,5 @@ defmodule WandererAppWeb.Gettext do
 
   See the [Gettext Docs](https://hexdocs.pm/gettext) for detailed usage.
   """
-  use Gettext, otp_app: :wanderer_app
+  use Gettext.Backend, otp_app: :wanderer_app
 end

--- a/lib/wanderer_app_web/live/map/event_handlers/map_pings_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_pings_event_handler.ex
@@ -242,8 +242,8 @@ defmodule WandererAppWeb.MapPingsEventHandler do
   # Catch-all for cancel_ping to debug why it doesn't match
   def handle_ui_event(
         "cancel_ping",
-        event,
-        %{assigns: assigns} = socket
+        _event,
+        socket
       ) do
     {:noreply, socket}
   end


### PR DESCRIPTION
I noticed that not all characters were being included in the `/api/map/character-activity`. It was limited to characters that had passages recorded. These changes expand the results to incldue all characters with activity, not only passages. The changes include removing some unused code and making some helpers the same shape.