### PR TITLE
feat: set any connection as bridge

### DIFF
--- a/assets/js/hooks/Mapper/components/map/components/ContextMenuConnection/ContextMenuConnection.tsx
+++ b/assets/js/hooks/Mapper/components/map/components/ContextMenuConnection/ContextMenuConnection.tsx
@@ -20,7 +20,7 @@ export interface ContextMenuConnectionProps {
   onChangeShipSizeStatus(state: ShipSizeStatus): void;
   onChangeType(type: ConnectionType): void;
   onToggleMassSave(isLocked: boolean): void;
-  onToggleBbridge(isBridge: boolean): void;
+  onToggleBridge(isBridge: boolean): void;
   onHide(): void;
   edge?: Edge<SolarSystemConnection>;
 }
@@ -67,11 +67,6 @@ export const ContextMenuConnection: React.FC<ContextMenuConnectionProps> = ({
 
     if (edge.data?.type === ConnectionType.gate) {
       return [
-         {
-          label: `Set as Bridge`,
-          icon: 'pi hero-forward',
-          command: () => onChangeType(ConnectionType.bridge),
-        },
         {
           label: 'Disconnect',
           icon: PrimeIcons.TRASH,
@@ -124,12 +119,7 @@ export const ContextMenuConnection: React.FC<ContextMenuConnectionProps> = ({
         command: () => onToggleMassSave(!edge.data?.locked),
       },
       ...(bothNullsec
-        ? [/*
-            { //ability only ros bridge between nullsecs
-              label: `Set as Bridge`,
-              icon: 'pi hero-forward',
-              command: () => onChangeType(ConnectionType.bridge),
-            },*/
+        ? [
           ]
         : []),
       {

--- a/assets/js/hooks/Mapper/components/map/components/ContextMenuConnection/ContextMenuConnection.tsx
+++ b/assets/js/hooks/Mapper/components/map/components/ContextMenuConnection/ContextMenuConnection.tsx
@@ -20,6 +20,7 @@ export interface ContextMenuConnectionProps {
   onChangeShipSizeStatus(state: ShipSizeStatus): void;
   onChangeType(type: ConnectionType): void;
   onToggleMassSave(isLocked: boolean): void;
+  onToggleBbridge(isBridge: boolean): void;
   onHide(): void;
   edge?: Edge<SolarSystemConnection>;
 }
@@ -32,6 +33,7 @@ export const ContextMenuConnection: React.FC<ContextMenuConnectionProps> = ({
   onChangeShipSizeStatus,
   onChangeType,
   onToggleMassSave,
+  onToggleBridge,
   onHide,
   edge,
 }) => {
@@ -65,6 +67,11 @@ export const ContextMenuConnection: React.FC<ContextMenuConnectionProps> = ({
 
     if (edge.data?.type === ConnectionType.gate) {
       return [
+         {
+          label: `Set as Bridge`,
+          icon: 'pi hero-forward',
+          command: () => onChangeType(ConnectionType.bridge),
+        },
         {
           label: 'Disconnect',
           icon: PrimeIcons.TRASH,
@@ -103,6 +110,11 @@ export const ContextMenuConnection: React.FC<ContextMenuConnectionProps> = ({
           );
         },
       },
+       {
+          label: `Set as Bridge`,
+          icon: 'pi hero-forward',
+          command: () => onChangeType(ConnectionType.bridge),
+        },
       {
         label: `Save mass`,
         className: clsx({
@@ -112,12 +124,12 @@ export const ContextMenuConnection: React.FC<ContextMenuConnectionProps> = ({
         command: () => onToggleMassSave(!edge.data?.locked),
       },
       ...(bothNullsec
-        ? [
-            {
+        ? [/*
+            { //ability only ros bridge between nullsecs
               label: `Set as Bridge`,
               icon: 'pi hero-forward',
               command: () => onChangeType(ConnectionType.bridge),
-            },
+            },*/
           ]
         : []),
       {
@@ -133,6 +145,7 @@ export const ContextMenuConnection: React.FC<ContextMenuConnectionProps> = ({
     onChangeType,
     onChangeShipSizeStatus,
     onToggleMassSave,
+    onToggleBridge,
     onChangeMassState,
   ]);
 


### PR DESCRIPTION
yeah, pathfinder had it, and i think some asked for this on discord
its just for ease-of-navigation so can be toggled at will so ppl can see where to go - those who will need it will use it. 

<img width="895" height="536" alt="Zrzut ekranu 2026-07-25 122730" src="https://github.com/user-attachments/assets/7b428559-91e2-49c1-83bf-0203856cabfd" />

i gues could add some "if neighboring k-space-systems then set-gate", but this wont be used that much to bother faster do disconnect and draw new line if someone missclicks.