### PR TITLE
chore(ci): move every GitHub Action off the Node 20 runtime

### DIFF
--- a/.github/workflows/advanced-test.yml
+++ b/.github/workflows/advanced-test.yml
@@ -24,7 +24,7 @@ jobs:
     if: ${{ github.base_ref == 'develop' || (github.ref == 'refs/heads/develop' && github.event_name == 'push') }}
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: 👀 Read app name
@@ -71,12 +71,12 @@ jobs:
           elixir-version: ${{matrix.elixir}}
         # nix build would also work here because `todos` is the default package
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: 😅 Cache deps
         id: cache-deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-elixir-deps
         with:
@@ -87,7 +87,7 @@ jobs:
             ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
       - name: 😅 Cache compiled build
         id: cache-build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-compiled-build
         with:

--- a/.github/workflows/advanced-test.yml
+++ b/.github/workflows/advanced-test.yml
@@ -27,13 +27,6 @@ jobs:
         uses: actions/checkout@v5
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: 👀 Read app name
-        uses: SebRollen/toml-action@v1.0.0
-        id: app_name
-        with:
-          file: "fly.toml"
-          field: "app"
-
       - name: 🚀 Deploy Test
         run: flyctl deploy --remote-only --wait-timeout=300 --ha=false
         env:

--- a/.github/workflows/advanced-test.yml
+++ b/.github/workflows/advanced-test.yml
@@ -24,7 +24,7 @@ jobs:
     if: ${{ github.base_ref == 'develop' || (github.ref == 'refs/heads/develop' && github.event_name == 'push') }}
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: 🚀 Deploy Test
@@ -64,12 +64,12 @@ jobs:
           elixir-version: ${{matrix.elixir}}
         # nix build would also work here because `todos` is the default package
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: 😅 Cache deps
         id: cache-deps
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         env:
           cache-name: cache-elixir-deps
         with:
@@ -80,7 +80,7 @@ jobs:
             ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
       - name: 😅 Cache compiled build
         id: cache-build
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         env:
           cache-name: cache-compiled-build
         with:

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -50,13 +50,13 @@ jobs:
           elixir-version: ${{matrix.elixir}}
         # nix build would also work here because `todos` is the default package
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ssh-key: "${{ secrets.COMMIT_KEY }}"
           fetch-depth: 0
       - name: 😅 Cache deps
         id: cache-deps
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         env:
           cache-name: cache-elixir-deps
         with:
@@ -67,7 +67,7 @@ jobs:
             ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
       - name: 😅 Cache compiled build
         id: cache-build
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         env:
           cache-name: cache-compiled-build
         with:
@@ -118,7 +118,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.build.outputs.commit_hash }}
           fetch-depth: 0
@@ -164,7 +164,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
@@ -177,7 +177,7 @@ jobs:
       - docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-*
@@ -219,7 +219,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [docker, merge]
     steps:
-      - name: Discord Webhook Action
+      - name: Notify Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
           COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -236,6 +236,9 @@ jobs:
           ⚠️ This is an unstable development release for testing purposes.
           EOF
           )
+          # $(...) strips the trailing newline the YAML block scalar used to emit,
+          # so it is restored here; build.yml needs no equivalent because its value
+          # arrives through $GITHUB_OUTPUT with the newline intact.
           jq -n --arg content "$content" '{content: ($content + "\n")}' \
             | curl --fail-with-body -sS -X POST \
                 -H "Content-Type: application/json" \

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -50,13 +50,13 @@ jobs:
           elixir-version: ${{matrix.elixir}}
         # nix build would also work here because `todos` is the default package
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ssh-key: "${{ secrets.COMMIT_KEY }}"
           fetch-depth: 0
       - name: 😅 Cache deps
         id: cache-deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-elixir-deps
         with:
@@ -67,7 +67,7 @@ jobs:
             ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
       - name: 😅 Cache compiled build
         id: cache-build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-compiled-build
         with:
@@ -118,32 +118,32 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.build.outputs.commit_hash }}
           fetch-depth: 0
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.WANDERER_DOCKER_USER }}
           password: ${{ secrets.WANDERER_DOCKER_PASSWORD }}
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .
@@ -164,7 +164,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
@@ -177,24 +177,24 @@ jobs:
       - docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.WANDERER_DOCKER_USER }}
           password: ${{ secrets.WANDERER_DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ env.REGISTRY_IMAGE }}

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -220,15 +220,22 @@ jobs:
     needs: [docker, merge]
     steps:
       - name: Discord Webhook Action
-        uses: tsickert/discord-webhook@v5.3.0
-        with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
-          content: |
-            📣 New develop release available 🚀
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          content=$(cat <<EOF
+          📣 New develop release available 🚀
 
-            **Commit**: `${{ github.sha }}`
-            **Status**: Development/Testing Release
+          **Commit**: \`${COMMIT_SHA}\`
+          **Status**: Development/Testing Release
 
-            Docker image: `wandererltd/community-edition:develop`
+          Docker image: \`wandererltd/community-edition:develop\`
 
-            ⚠️ This is an unstable development release for testing purposes.
+          ⚠️ This is an unstable development release for testing purposes.
+          EOF
+          )
+          jq -n --arg content "$content" '{content: ($content + "\n")}' \
+            | curl --fail-with-body -sS -X POST \
+                -H "Content-Type: application/json" \
+                -d @- "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -223,6 +223,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
           COMMIT_SHA: ${{ github.sha }}
+        shell: bash
         run: |
           content=$(cat <<EOF
           📣 New develop release available 🚀

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,9 +199,12 @@ jobs:
         id: release-notes
         env:
           RELEASE_TAG: ${{ steps.get-latest-tag.outputs.tag }}
+        shell: bash
         run: |
           python3 <<'PY' > /tmp/release-notes.txt
           import os
+          # Carried over unchanged from the gh-truncate-string-action inputs this replaced;
+          # don't raise toward Discord's 2000-char message cap without checking that action's intent.
           MAX_LENGTH = 500
           TRUNCATION_SYMBOL = '…'
           header = (
@@ -309,6 +312,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           RELEASE_NOTES: ${{ needs.docker.outputs.release-notes }}
+        shell: bash
         run: |
           jq -n --arg content "$RELEASE_NOTES" '{content: $content}' \
             | curl --fail-with-body -sS -X POST \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       release-tag: ${{ steps.get-latest-tag.outputs.tag }}
-      release-notes: ${{ steps.get-content.outputs.string }}
+      release-notes: ${{ steps.release-notes.outputs.content }}
     permissions:
       checks: write
       contents: write
@@ -195,23 +195,34 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      - uses: markpatterson27/markdown-to-output@v1
-        id: extract-changelog
-        with:
-          filepath: CHANGELOG.md
-
-      - name: Get content
-        uses: 2428392/gh-truncate-string-action@v1.3.0
-        id: get-content
-        with:
-          stringToTruncate: |
-            📣 Wanderer new release available 🎉
-
-            **Version**: ${{ steps.get-latest-tag.outputs.tag }}
-
-            ${{ steps.extract-changelog.outputs.body }}
-          maxLength: 500
-          truncationSymbol: "…"
+      - name: Build release notes
+        id: release-notes
+        env:
+          RELEASE_TAG: ${{ steps.get-latest-tag.outputs.tag }}
+        run: |
+          python3 <<'PY' > /tmp/release-notes.txt
+          import os
+          MAX_LENGTH = 500
+          TRUNCATION_SYMBOL = '…'
+          header = (
+              '\U0001F4E3 Wanderer new release available \U0001F389\n\n'
+              '**Version**: ' + os.environ['RELEASE_TAG'] + '\n\n'
+          )
+          with open('CHANGELOG.md', encoding='utf-8') as fh:
+              content = (header + fh.read() + '\n').strip()
+          units = content.encode('utf-16-le')
+          if len(units) // 2 > MAX_LENGTH:
+              cut = (MAX_LENGTH - len(TRUNCATION_SYMBOL)) * 2
+              content = units[:cut].decode('utf-16-le', 'replace') + TRUNCATION_SYMBOL
+          print(content, end='')
+          PY
+          delimiter="EOF_$(openssl rand -hex 16)"
+          {
+            echo "content<<${delimiter}"
+            cat /tmp/release-notes.txt
+            echo ""
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
 
   merge:
     runs-on: ubuntu-latest
@@ -295,7 +306,11 @@ jobs:
     needs: [docker, merge]
     steps:
       - name: Discord Webhook Action
-        uses: tsickert/discord-webhook@v5.3.0
-        with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          content: ${{ needs.docker.outputs.release-notes }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RELEASE_NOTES: ${{ needs.docker.outputs.release-notes }}
+        run: |
+          jq -n --arg content "$RELEASE_NOTES" '{content: $content}' \
+            | curl --fail-with-body -sS -X POST \
+                -H "Content-Type: application/json" \
+                -d @- "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,13 @@ jobs:
           elixir-version: ${{matrix.elixir}}
         # nix build would also work here because `todos` is the default package
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ssh-key: "${{ secrets.COMMIT_KEY }}"
           fetch-depth: 0
       - name: 😅 Cache deps
         id: cache-deps
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         env:
           cache-name: cache-elixir-deps
         with:
@@ -67,7 +67,7 @@ jobs:
             ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
       - name: 😅 Cache compiled build
         id: cache-build
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         env:
           cache-name: cache-compiled-build
         with:
@@ -131,7 +131,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.build.outputs.commit_hash }}
           fetch-depth: 0
@@ -188,7 +188,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
@@ -233,7 +233,7 @@ jobs:
       - docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-*
@@ -278,7 +278,7 @@ jobs:
     needs: build
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -308,7 +308,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [docker, merge]
     steps:
-      - name: Discord Webhook Action
+      - name: Notify Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           RELEASE_NOTES: ${{ needs.docker.outputs.release-notes }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,13 @@ jobs:
           elixir-version: ${{matrix.elixir}}
         # nix build would also work here because `todos` is the default package
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ssh-key: "${{ secrets.COMMIT_KEY }}"
           fetch-depth: 0
       - name: 😅 Cache deps
         id: cache-deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-elixir-deps
         with:
@@ -67,7 +67,7 @@ jobs:
             ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
       - name: 😅 Cache compiled build
         id: cache-build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-compiled-build
         with:
@@ -131,14 +131,14 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.build.outputs.commit_hash }}
           fetch-depth: 0
 
       - name: Get Release Tag
         id: get-latest-tag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        uses: "WyriHaximus/github-action-get-previous-tag@v2"
         with:
           fallback: 1.0.0
 
@@ -149,25 +149,25 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.WANDERER_DOCKER_USER }}
           password: ${{ secrets.WANDERER_DOCKER_PASSWORD }}
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .
@@ -188,7 +188,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
@@ -219,24 +219,24 @@ jobs:
       - docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.WANDERER_DOCKER_USER }}
           password: ${{ secrets.WANDERER_DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ env.REGISTRY_IMAGE }}
@@ -264,18 +264,18 @@ jobs:
     needs: build
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Get Release Tag
         id: get-latest-tag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        uses: "WyriHaximus/github-action-get-previous-tag@v2"
         with:
           fallback: 1.0.0
 
       - name: 🏷 Create Draft Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.get-latest-tag.outputs.tag }}
           name: Release ${{ steps.get-latest-tag.outputs.tag }}

--- a/.github/workflows/flaky-test-detection.yml
+++ b/.github/workflows/flaky-test-detection.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🏗️ Setup Elixir & Erlang
         uses: erlef/setup-beam@v1
@@ -52,7 +52,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
 
       - name: 📦 Restore dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: deps-cache
         with:
           path: |
@@ -98,7 +98,7 @@ jobs:
 
       - name: 📊 Upload flaky test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: flaky-test-report
           path: flaky_report.json
@@ -106,7 +106,7 @@ jobs:
 
       - name: 💬 Comment on flaky tests
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -226,10 +226,10 @@ jobs:
     
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Download previous reports
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: flaky-test-detection.yml
           workflow_conclusion: completed
@@ -291,7 +291,7 @@ jobs:
           EOF
 
       - name: 💾 Save analysis
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-stability-analysis
           path: |

--- a/.github/workflows/flaky-test-detection.yml
+++ b/.github/workflows/flaky-test-detection.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 🏗️ Setup Elixir & Erlang
         uses: erlef/setup-beam@v1
@@ -52,7 +52,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
 
       - name: 📦 Restore dependencies cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: deps-cache
         with:
           path: |
@@ -98,7 +98,7 @@ jobs:
 
       - name: 📊 Upload flaky test report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: flaky-test-report
           path: flaky_report.json
@@ -106,7 +106,7 @@ jobs:
 
       - name: 💬 Comment on flaky tests
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -226,7 +226,7 @@ jobs:
     
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 📥 Download previous reports
         uses: dawidd6/action-download-artifact@v21
@@ -291,7 +291,7 @@ jobs:
           EOF
 
       - name: 💾 Save analysis
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-stability-analysis
           path: |

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -34,10 +34,13 @@ permissions:
   # not cover. Without it the download 403s and the workflow silently posts
   # nothing.
   actions: read
-  # Read-only PR access is only used to verify the artifact's PR number against
-  # the triggering run's head SHA. The comment itself is an *issue* comment, so
-  # `issues: write` is the scope that grants posting.
-  pull-requests: read
+  # Posting the comment needs BOTH of the scopes below. The body goes to the
+  # issue-comments endpoint, but the target is a pull request, and GitHub gates
+  # that on the pull-requests scope as well: with `pull-requests: read` the POST
+  # 403s and answers `x-accepted-github-permissions: issues=write;
+  # pull_requests=write`. PR access is otherwise only read for verifying the
+  # artifact's PR number against the triggering run's head SHA.
+  pull-requests: write
   issues: write
 
 jobs:

--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     steps:
       - name: executing remote ssh commands using password
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Elixir/OTP
         uses: erlef/setup-beam@v1
@@ -47,7 +47,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
 
       - name: Cache Elixir dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Elixir/OTP
         uses: erlef/setup-beam@v1
@@ -47,7 +47,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
 
       - name: Cache Elixir dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -256,7 +256,7 @@ jobs:
       - name: Find existing PR comment
         if: github.event_name == 'pull_request'
         id: find_comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
@@ -264,7 +264,7 @@ jobs:
 
       - name: Create or update PR comment
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
GitHub is retiring the Node 20 action runtime and our workflows still run on it. Every action in `.github/workflows/` is moved to a version that runs on Node 24, plus a one-line permissions fix so the test-results comment added in #636 can actually post.

@DmitryPopov @DanSylvest
