### PR TITLE
fix(map): duplicating a map fails with an error

### DIFF
--- a/lib/wanderer_app/map/operations/duplication.ex
+++ b/lib/wanderer_app/map/operations/duplication.ex
@@ -94,28 +94,11 @@ defmodule WandererApp.Map.Operations.Duplication do
 
   # Copy a single system
   defp copy_single_system(source_system, new_map_id) do
-    # Get all attributes from the source system, excluding system-managed fields and metadata
-    excluded_fields = [
-      # System managed fields
-      :id,
-      :inserted_at,
-      :updated_at,
-      :map_id,
-      :map,
-      # Ash/Ecto metadata fields
-      :__meta__,
-      :__lateral_join_source__,
-      :__metadata__,
-      :__order__,
-      :aggregates,
-      :calculations
-    ]
-
-    # Convert the source system struct to a map and filter out excluded fields
+    # Same allowlist approach as connections -- see acceptable_attrs/3 below for
+    # why a denylist was the wrong shape here.
     system_attrs =
       source_system
-      |> Map.from_struct()
-      |> Map.drop(excluded_fields)
+      |> acceptable_attrs(MapSystem, :create)
       |> Map.put(:map_id, new_map_id)
 
     MapSystem.create(system_attrs)
@@ -145,32 +128,39 @@ defmodule WandererApp.Map.Operations.Duplication do
 
   # Copy a single connection with updated system references
   defp copy_single_connection(source_connection, new_map_id, system_mapping) do
-    # Get all attributes from the source connection, excluding system-managed fields and metadata
-    excluded_fields = [
-      # System managed fields
-      :id,
-      :inserted_at,
-      :updated_at,
-      :map_id,
-      :map,
-      # Ash/Ecto metadata fields
-      :__meta__,
-      :__lateral_join_source__,
-      :__metadata__,
-      :__order__,
-      :aggregates,
-      :calculations
-    ]
-
-    # Convert the source connection struct to a map and filter out excluded fields
     connection_attrs =
       source_connection
-      |> Map.from_struct()
-      |> Map.drop(excluded_fields)
+      |> acceptable_attrs(MapConnection, :create)
       |> Map.put(:map_id, new_map_id)
       |> update_system_references(system_mapping)
 
     MapConnection.create(connection_attrs)
+  end
+
+  # Build the attribute map from what the target action actually ACCEPTS,
+  # rather than by dropping a hand-maintained list of fields to exclude.
+  #
+  # This previously used `Map.from_struct() |> Map.drop(excluded_fields)`, a
+  # denylist: every attribute not explicitly named was forwarded to `create`.
+  # When commit 2f86fc9f added `locked_at` / `locked_by` / `locked_by_id` to
+  # MapConnection without adding them to the `:create` accept list, duplication
+  # started failing with Ash.Error.Invalid.NoSuchInput and every map
+  # duplication returned 500.
+  #
+  # An allowlist derived from the action cannot drift: a new attribute is
+  # copied only if the action accepts it, and is silently skipped otherwise.
+  defp acceptable_attrs(source, resource, action_name) do
+    accepted =
+      resource
+      |> Ash.Resource.Info.action(action_name)
+      |> Map.get(:accept, [])
+      |> MapSet.new()
+
+    source
+    |> Map.from_struct()
+    |> Map.filter(fn {key, value} ->
+      MapSet.member?(accepted, key) and not match?(%Ash.NotLoaded{}, value)
+    end)
   end
 
   # Update system references in connection attributes using the system mapping
@@ -202,28 +192,31 @@ defmodule WandererApp.Map.Operations.Duplication do
     Logger.debug("Copying signatures for map #{source_map.id}")
 
     # Get signatures by iterating through systems
-    source_signatures = get_all_map_signatures(source_map.id, system_mapping)
+    with {:ok, source_signatures} <- get_all_map_signatures(source_map.id, system_mapping) do
+      Enum.reduce_while(source_signatures, {:ok, []}, fn source_signature,
+                                                         {:ok, acc_signatures} ->
+        case copy_single_signature(source_signature, new_map.id, system_mapping) do
+          {:ok, new_signature} ->
+            {:cont, {:ok, [new_signature | acc_signatures]}}
 
-    Enum.reduce_while(source_signatures, {:ok, []}, fn source_signature, {:ok, acc_signatures} ->
-      case copy_single_signature(source_signature, new_map.id, system_mapping) do
-        {:ok, new_signature} ->
-          {:cont, {:ok, [new_signature | acc_signatures]}}
-
-        {:error, reason} ->
-          {:halt, {:error, {:signature_copy_failed, reason}}}
-      end
-    end)
+          {:error, reason} ->
+            {:halt, {:error, {:signature_copy_failed, reason}}}
+        end
+      end)
+    end
   end
 
-  # Get all signatures for a map by querying each system
+  # Get all signatures for a map by querying each system. A read failure for any
+  # system aborts the copy with an error rather than silently omitting those
+  # signatures, which would return an incomplete duplicate reported as success.
   defp get_all_map_signatures(_source_map_id, system_mapping) do
     # Get source system IDs and query signatures for each
     source_system_ids = Map.keys(system_mapping)
 
-    Enum.flat_map(source_system_ids, fn system_id ->
-      case MapSystemSignature.by_system_id_all(%{system_id: system_id}) do
-        {:ok, signatures} -> signatures
-        {:error, _} -> []
+    Enum.reduce_while(source_system_ids, {:ok, []}, fn system_id, {:ok, acc} ->
+      case MapSystemSignature.by_system_id_all(system_id) do
+        {:ok, signatures} -> {:cont, {:ok, acc ++ signatures}}
+        {:error, reason} -> {:halt, {:error, {:signature_read_failed, reason}}}
       end
     end)
   end

--- a/lib/wanderer_app/map/operations/duplication.ex
+++ b/lib/wanderer_app/map/operations/duplication.ex
@@ -126,13 +126,16 @@ defmodule WandererApp.Map.Operations.Duplication do
     end
   end
 
-  # Copy a single connection with updated system references
-  defp copy_single_connection(source_connection, new_map_id, system_mapping) do
+  # Copy a single connection. `solar_system_source`/`solar_system_target` are
+  # EVE solar-system ids, which are identical between the source map and the
+  # duplicate, so no remapping is needed here (unlike `system_mapping`, which
+  # translates MapSystem UUIDs and is only used to resolve signatures' system
+  # references).
+  defp copy_single_connection(source_connection, new_map_id, _system_mapping) do
     connection_attrs =
       source_connection
       |> acceptable_attrs(MapConnection, :create)
       |> Map.put(:map_id, new_map_id)
-      |> update_system_references(system_mapping)
 
     MapConnection.create(connection_attrs)
   end
@@ -163,28 +166,6 @@ defmodule WandererApp.Map.Operations.Duplication do
     end)
   end
 
-  # Update system references in connection attributes using the system mapping
-  defp update_system_references(connection_attrs, system_mapping) do
-    connection_attrs
-    |> maybe_update_system_reference(:solar_system_source, system_mapping)
-    |> maybe_update_system_reference(:solar_system_target, system_mapping)
-  end
-
-  # Update a single system reference if it exists in the mapping
-  defp maybe_update_system_reference(attrs, field, system_mapping) do
-    case Map.get(attrs, field) do
-      nil ->
-        attrs
-
-      old_system_id ->
-        case Map.get(system_mapping, old_system_id) do
-          # Keep original if no mapping found
-          nil -> attrs
-          new_system_id -> Map.put(attrs, field, new_system_id)
-        end
-    end
-  end
-
   # Conditionally copy signatures if requested
   defp maybe_copy_signatures(_source_map, _new_map, _system_mapping, false), do: {:ok, []}
 
@@ -210,15 +191,23 @@ defmodule WandererApp.Map.Operations.Duplication do
   # system aborts the copy with an error rather than silently omitting those
   # signatures, which would return an incomplete duplicate reported as success.
   defp get_all_map_signatures(_source_map_id, system_mapping) do
-    # Get source system IDs and query signatures for each
+    # Get source system IDs and query signatures for each. `by_system_id/1`
+    # (unlike `by_system_id_all/1`) filters out soft-deleted signatures, so
+    # tombstones from the source map are never fetched to copy.
     source_system_ids = Map.keys(system_mapping)
 
-    Enum.reduce_while(source_system_ids, {:ok, []}, fn system_id, {:ok, acc} ->
-      case MapSystemSignature.by_system_id_all(system_id) do
-        {:ok, signatures} -> {:cont, {:ok, acc ++ signatures}}
-        {:error, reason} -> {:halt, {:error, {:signature_read_failed, reason}}}
-      end
-    end)
+    result =
+      Enum.reduce_while(source_system_ids, {:ok, []}, fn system_id, {:ok, acc} ->
+        case MapSystemSignature.by_system_id(system_id) do
+          {:ok, signatures} -> {:cont, {:ok, [signatures | acc]}}
+          {:error, reason} -> {:halt, {:error, {:signature_read_failed, reason}}}
+        end
+      end)
+
+    case result do
+      {:ok, acc} -> {:ok, Enum.concat(acc)}
+      error -> error
+    end
   end
 
   # Copy a single signature with updated system reference
@@ -226,31 +215,11 @@ defmodule WandererApp.Map.Operations.Duplication do
     new_system_id = Map.get(system_mapping, source_signature.system_id)
 
     if new_system_id do
-      # Get all attributes from the source signature, excluding system-managed fields and metadata
-      excluded_fields = [
-        # System managed fields
-        :id,
-        :inserted_at,
-        :updated_at,
-        :system_id,
-        :system,
-        # Fields not accepted by create action
-        :linked_system_id,
-        :update_forced_at,
-        # Ash/Ecto metadata fields
-        :__meta__,
-        :__lateral_join_source__,
-        :__metadata__,
-        :__order__,
-        :aggregates,
-        :calculations
-      ]
-
-      # Convert the source signature struct to a map and filter out excluded fields
+      # Same allowlist approach as systems/connections -- see acceptable_attrs/3
+      # above for why a denylist was the wrong shape here.
       signature_attrs =
         source_signature
-        |> Map.from_struct()
-        |> Map.drop(excluded_fields)
+        |> acceptable_attrs(MapSystemSignature, :create)
         |> Map.put(:system_id, new_system_id)
 
       MapSystemSignature.create(signature_attrs)

--- a/test/integration/map_duplication_api_controller_success_test.exs
+++ b/test/integration/map_duplication_api_controller_success_test.exs
@@ -237,6 +237,60 @@ defmodule WandererAppWeb.MapDuplicationAPIControllerSuccessTest do
       assert stargate_connection.solar_system_source == 30_000_142
       assert stargate_connection.solar_system_target == 30_000_144
     end
+
+    test "duplicated map contains copied signatures when copy_signatures is true", %{
+      conn: conn,
+      source_map: source_map
+    } do
+      duplication_params = %{
+        "name" => "Signature Copy Test",
+        "copy_signatures" => true
+      }
+
+      conn = post(conn, ~p"/api/maps/#{source_map.slug}/duplicate", duplication_params)
+
+      assert %{"data" => %{"id" => new_map_id}} = json_response(conn, 201)
+
+      # The signature belongs to a system, not the map, so resolve the copied
+      # Jita system first and then read its signatures.
+      {:ok, new_systems} = WandererApp.Api.MapSystem.read_all_by_map(%{map_id: new_map_id})
+      new_jita = Enum.find(new_systems, &(&1.name == "Jita"))
+      assert new_jita != nil
+
+      {:ok, new_signatures} = WandererApp.Api.MapSystemSignature.by_system_id_all(new_jita.id)
+
+      # Previously `get_all_map_signatures/2` called `by_system_id_all/1` with a
+      # map instead of a bare id and swallowed the resulting error into `[]`, so
+      # duplication reported success with zero signatures copied.
+      assert length(new_signatures) == 1
+
+      copied = hd(new_signatures)
+      assert copied.eve_id == "ABC-123"
+      assert copied.name == "Test Wormhole"
+      assert copied.type == "wormhole"
+      assert copied.system_id == new_jita.id
+    end
+
+    test "duplicated map has no signatures when copy_signatures is false", %{
+      conn: conn,
+      source_map: source_map
+    } do
+      duplication_params = %{
+        "name" => "Signature Skip Test",
+        "copy_signatures" => false
+      }
+
+      conn = post(conn, ~p"/api/maps/#{source_map.slug}/duplicate", duplication_params)
+
+      assert %{"data" => %{"id" => new_map_id}} = json_response(conn, 201)
+
+      {:ok, new_systems} = WandererApp.Api.MapSystem.read_all_by_map(%{map_id: new_map_id})
+      new_jita = Enum.find(new_systems, &(&1.name == "Jita"))
+      assert new_jita != nil
+
+      {:ok, new_signatures} = WandererApp.Api.MapSystemSignature.by_system_id_all(new_jita.id)
+      assert new_signatures == []
+    end
   end
 
   describe "error handling for map duplication" do

--- a/test/integration/map_duplication_api_controller_success_test.exs
+++ b/test/integration/map_duplication_api_controller_success_test.exs
@@ -271,6 +271,43 @@ defmodule WandererAppWeb.MapDuplicationAPIControllerSuccessTest do
       assert copied.system_id == new_jita.id
     end
 
+    test "soft-deleted signatures are not copied when copy_signatures is true", %{
+      conn: conn,
+      source_map: source_map,
+      system1: system1
+    } do
+      _deleted_signature =
+        insert(:map_system_signature, %{
+          system_id: system1.id,
+          eve_id: "DEL-999",
+          name: "Deleted Wormhole",
+          type: "wormhole",
+          deleted: true
+        })
+
+      duplication_params = %{
+        "name" => "Soft Delete Copy",
+        "copy_signatures" => true
+      }
+
+      conn = post(conn, ~p"/api/maps/#{source_map.slug}/duplicate", duplication_params)
+
+      assert %{"data" => %{"id" => new_map_id}} = json_response(conn, 201)
+
+      {:ok, new_systems} = WandererApp.Api.MapSystem.read_all_by_map(%{map_id: new_map_id})
+      new_jita = Enum.find(new_systems, &(&1.name == "Jita"))
+      assert new_jita != nil
+
+      {:ok, new_signatures} = WandererApp.Api.MapSystemSignature.by_system_id_all(new_jita.id)
+
+      # Only the live signature (from the top-level `setup`) should be
+      # copied; the soft-deleted one must not resurface as a tombstone in
+      # the duplicate.
+      assert length(new_signatures) == 1
+      assert hd(new_signatures).eve_id == "ABC-123"
+      assert hd(new_signatures).deleted == false
+    end
+
     test "duplicated map has no signatures when copy_signatures is false", %{
       conn: conn,
       source_map: source_map


### PR DESCRIPTION
Duplicating a map fails with a server error, and before that it silently produced copies with no signatures in them. Both are fixed.

Merge this before #642.

@DmitryPopov @DanSylvest

