### PR TITLE
ci: replace the last four node20 actions

### DIFF
--- a/.github/workflows/advanced-test.yml
+++ b/.github/workflows/advanced-test.yml
@@ -27,13 +27,6 @@ jobs:
         uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: 👀 Read app name
-        uses: SebRollen/toml-action@v1.0.0
-        id: app_name
-        with:
-          file: "fly.toml"
-          field: "app"
-
       - name: 🚀 Deploy Test
         run: flyctl deploy --remote-only --wait-timeout=300 --ha=false
         env:

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -236,6 +236,9 @@ jobs:
           ⚠️ This is an unstable development release for testing purposes.
           EOF
           )
+          # $(...) strips the trailing newline the YAML block scalar used to emit,
+          # so it is restored here; build.yml needs no equivalent because its value
+          # arrives through $GITHUB_OUTPUT with the newline intact.
           jq -n --arg content "$content" '{content: ($content + "\n")}' \
             | curl --fail-with-body -sS -X POST \
                 -H "Content-Type: application/json" \

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -220,15 +220,22 @@ jobs:
     needs: [docker, merge]
     steps:
       - name: Discord Webhook Action
-        uses: tsickert/discord-webhook@v5.3.0
-        with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
-          content: |
-            📣 New develop release available 🚀
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          content=$(cat <<EOF
+          📣 New develop release available 🚀
 
-            **Commit**: `${{ github.sha }}`
-            **Status**: Development/Testing Release
+          **Commit**: \`${COMMIT_SHA}\`
+          **Status**: Development/Testing Release
 
-            Docker image: `wandererltd/community-edition:develop`
+          Docker image: \`wandererltd/community-edition:develop\`
 
-            ⚠️ This is an unstable development release for testing purposes.
+          ⚠️ This is an unstable development release for testing purposes.
+          EOF
+          )
+          jq -n --arg content "$content" '{content: ($content + "\n")}' \
+            | curl --fail-with-body -sS -X POST \
+                -H "Content-Type: application/json" \
+                -d @- "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -223,6 +223,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
           COMMIT_SHA: ${{ github.sha }}
+        shell: bash
         run: |
           content=$(cat <<EOF
           📣 New develop release available 🚀

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,9 +199,12 @@ jobs:
         id: release-notes
         env:
           RELEASE_TAG: ${{ steps.get-latest-tag.outputs.tag }}
+        shell: bash
         run: |
           python3 <<'PY' > /tmp/release-notes.txt
           import os
+          # Carried over unchanged from the gh-truncate-string-action inputs this replaced;
+          # don't raise toward Discord's 2000-char message cap without checking that action's intent.
           MAX_LENGTH = 500
           TRUNCATION_SYMBOL = '…'
           header = (
@@ -309,6 +312,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           RELEASE_NOTES: ${{ needs.docker.outputs.release-notes }}
+        shell: bash
         run: |
           jq -n --arg content "$RELEASE_NOTES" '{content: $content}' \
             | curl --fail-with-body -sS -X POST \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       release-tag: ${{ steps.get-latest-tag.outputs.tag }}
-      release-notes: ${{ steps.get-content.outputs.string }}
+      release-notes: ${{ steps.release-notes.outputs.content }}
     permissions:
       checks: write
       contents: write
@@ -195,23 +195,34 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      - uses: markpatterson27/markdown-to-output@v1
-        id: extract-changelog
-        with:
-          filepath: CHANGELOG.md
-
-      - name: Get content
-        uses: 2428392/gh-truncate-string-action@v1.3.0
-        id: get-content
-        with:
-          stringToTruncate: |
-            📣 Wanderer new release available 🎉
-
-            **Version**: ${{ steps.get-latest-tag.outputs.tag }}
-
-            ${{ steps.extract-changelog.outputs.body }}
-          maxLength: 500
-          truncationSymbol: "…"
+      - name: Build release notes
+        id: release-notes
+        env:
+          RELEASE_TAG: ${{ steps.get-latest-tag.outputs.tag }}
+        run: |
+          python3 <<'PY' > /tmp/release-notes.txt
+          import os
+          MAX_LENGTH = 500
+          TRUNCATION_SYMBOL = '…'
+          header = (
+              '\U0001F4E3 Wanderer new release available \U0001F389\n\n'
+              '**Version**: ' + os.environ['RELEASE_TAG'] + '\n\n'
+          )
+          with open('CHANGELOG.md', encoding='utf-8') as fh:
+              content = (header + fh.read() + '\n').strip()
+          units = content.encode('utf-16-le')
+          if len(units) // 2 > MAX_LENGTH:
+              cut = (MAX_LENGTH - len(TRUNCATION_SYMBOL)) * 2
+              content = units[:cut].decode('utf-16-le', 'replace') + TRUNCATION_SYMBOL
+          print(content, end='')
+          PY
+          delimiter="EOF_$(openssl rand -hex 16)"
+          {
+            echo "content<<${delimiter}"
+            cat /tmp/release-notes.txt
+            echo ""
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
 
   merge:
     runs-on: ubuntu-latest
@@ -295,7 +306,11 @@ jobs:
     needs: [docker, merge]
     steps:
       - name: Discord Webhook Action
-        uses: tsickert/discord-webhook@v5.3.0
-        with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          content: ${{ needs.docker.outputs.release-notes }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RELEASE_NOTES: ${{ needs.docker.outputs.release-notes }}
+        run: |
+          jq -n --arg content "$RELEASE_NOTES" '{content: $content}' \
+            | curl --fail-with-body -sS -X POST \
+                -H "Content-Type: application/json" \
+                -d @- "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
Completes the Node 20 sweep started in #638. That PR bumped every action with a node24 release; these four had none, so they were left behind.

GitHub removes Node 20 from runners on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), `Node20RemovalDate` in `actions/runner`). Since 2026-06-16 the runner has silently executed `runs.using: node20` on Node 24 via a compatibility shim, so these still work today — but the shim expires with the removal.

| Action | Latest | License | node24? |
|---|---|---|---|
| `markpatterson27/markdown-to-output` | v1.2.1 (2024-05) | MIT | none |
| `SebRollen/toml-action` | v1.2.0 (2024-01) | **none** | none |
| `2428392/gh-truncate-string-action` | v1.4.1 (2024-12) | **none** | PR #15, unmerged |
| `tsickert/discord-webhook` | v7.0.0 (2025-03) | MIT | issue #199, no reply |

No node24 release exists for any of them, so bumping was not an option. `toml-action` and `gh-truncate-string-action` report `license: null`, so forking was not either.

## Changes

**1. `advanced-test.yml` — delete the `toml-action` step.** It read `app` from `fly.toml` into `steps.app_name.outputs.value`, which is referenced nowhere in the repo. The next step runs `flyctl deploy --remote-only` with no `--app` flag; flyctl resolves the app from `fly.toml` itself.

**2. `build.yml` — inline the changelog chain.** `markdown-to-output` → `gh-truncate-string-action` → `discord-webhook` becomes two `run:` steps. Stripped down, those actions were `cat CHANGELOG.md`, `String.slice()`, and one JSON POST.

**3. `build-develop.yml` — inline the Discord webhook.** Static literal message, so a heredoc into `jq` + `curl`.

## On reimplementing an action's logic

The truncation is the one piece with real behavior worth preserving, so it was verified rather than eyeballed: the **real `gh-truncate-string-action@v1.3.0` was run as an oracle** and its output diffed byte-for-byte against the replacement across **51 cases** — the actual `CHANGELOG.md`, empty input, all-emoji, CJK, shell metacharacters, boundary ±1, and every UTF-16 surrogate-split position from 420–460.

That testing caught three things a straightforward rewrite gets wrong:

- Length is measured in **UTF-16 code units**, not codepoints. The header's 📣 and 🎉 are astral (2 units each), so codepoint slicing cuts in the wrong place.
- `@actions/core.getInput` **trims** its input.
- When the cut splits a surrogate pair, JS keeps the **lone high surrogate**, which becomes U+FFFD in `$GITHUB_OUTPUT`. Python must decode with `errors='replace'` to match — `surrogatepass` produces different bytes, and strict decoding produces a 499-unit string instead of 500.

`maxLength: 500` and the `…` symbol are **unchanged**. 500 dates to this repo's initial commit and is a deliberate style choice, not Discord's limit (which is 2000) — there's now a comment on the constant saying so.

## Notes for review

- **Injection safety.** Changelog content never enters a shell string: `python3` reads it from disk, and it reaches `curl` via `jq --arg`. Backticks, quotes, and `$` in release notes cannot be interpreted. The `$GITHUB_OUTPUT` heredoc uses an `openssl rand` delimiter — that's a security control, not decoration: without it a changelog line could forge the terminator.
- **`build-develop.yml` is not runnable as raw text.** Its heredoc terminator is indented and only works after the runner dedents the `run: |` block scalar. Verified by parsing with js-yaml and executing the parsed value.
- **The two files use different styles** (python3 + delimiter vs shell heredoc) because `build.yml` carries untrusted multi-line content across a job boundary while `build-develop.yml` is a static literal.
- **`shell: bash`** is set on the new steps so Actions uses `-eo pipefail`; without it a failing `jq` in `jq | curl` exits 0.
- `python3` and `jq` are already used elsewhere in these workflows (`flaky-test-detection.yml`, `build-develop.yml`).

## Verification

- Truncation byte-identical to the real action across 51 differential cases
- Both Discord payloads POSTed to a scratch webhook: HTTP 200, messages confirmed rendering correctly
- Failure path confirmed loud: empty content → HTTP 400 → `curl` exit 22 → step fails
- `actionlint`: 12 pre-existing findings before and after, zero difference

**Not testable pre-merge:** the `docker` → `notify` cross-job `$GITHUB_OUTPUT` handoff (needs a real push to `main`), and `advanced-test.yml` (runs only on `develop`). If something slipped through, the `notify` job fails *after* the release is published — loud, non-corrupting, recoverable by posting manually.

## Known follow-up (not addressed here)

About 46% of the 500-character budget is consumed by compare-URLs, and the announced version's own changelog section is often empty — so the message can show content from *older* releases. That's current behavior, reproduced faithfully. Fixing it means extracting only the newest section, which changes what the announcement says and belongs in its own PR.

One deliberate behavior change worth flagging: `markdown-to-output` ran **nunjucks templating** over `CHANGELOG.md`. Since the changelog is generated from commit messages, a future commit containing `{{` would have been silently deleted or thrown and failed the release. The replacement treats it as literal text.
