### PR TITLE
Add spawn type and direction options to auto bookmarks

### DIFF
--- a/assets/js/hooks/Mapper/components/mapInterface/components/SystemLinkSignatureDialog/hooks/useLinkSignature.ts
+++ b/assets/js/hooks/Mapper/components/mapInterface/components/SystemLinkSignatureDialog/hooks/useLinkSignature.ts
@@ -52,6 +52,7 @@ export const useLinkSignature = ({ data, targetSystemClassGroup }: UseLinkSignat
         targetSystemClassGroup,
         targetSystemUuid,
         targetSolarSystemIdStr,
+        sourceSystem?.system_static_info?.statics,
       );
 
       if (shouldUpdate) {

--- a/assets/js/hooks/Mapper/components/mapInterface/components/SystemLinkSignatureDialog/hooks/useLinkSignature.ts
+++ b/assets/js/hooks/Mapper/components/mapInterface/components/SystemLinkSignatureDialog/hooks/useLinkSignature.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { handleAutoBookmark, numberToLetters } from '@/hooks/Mapper/helpers/bookmarkFormatHelper.ts';
 import { parseSignatureCustomInfo } from '@/hooks/Mapper/helpers/parseSignatureCustomInfo';
 import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
+import { getSystemStaticInfo } from '@/hooks/Mapper/mapRootProvider/hooks/useLoadSystemStatic';
 import { CommandLinkSignatureToSystem, SignatureGroup, SystemSignature } from '@/hooks/Mapper/types';
 import { OutCommand } from '@/hooks/Mapper/types/mapHandlers.ts';
 import { LabelsManager } from '@/hooks/Mapper/utils/labelsManager.ts';
@@ -52,7 +53,7 @@ export const useLinkSignature = ({ data, targetSystemClassGroup }: UseLinkSignat
         targetSystemClassGroup,
         targetSystemUuid,
         targetSolarSystemIdStr,
-        sourceSystem?.system_static_info?.statics,
+        getSystemStaticInfo(data.solar_system_source)?.statics,
       );
 
       if (shouldUpdate) {

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/BookmarkNameFormatSetting.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/BookmarkNameFormatSetting.tsx
@@ -40,7 +40,7 @@ const VARIABLES = [
   { id: '{temporary_name}', desc: 'Temporary name if set' },
   { id: '{description}', desc: 'Custom description' },
   { id: '{direction}', desc: 'Wormhole direction (e.g., In, Out)' },
-  { id: '{spawn}', desc: 'Spawn type for outgoing wormholes (e.g., Static, Wandering)' },
+  { id: '{spawn_type}', desc: 'Spawn type for outgoing wormholes (e.g., Static, Wandering)' },
 ];
 
 interface CustomMappingInputProps {

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/BookmarkNameFormatSetting.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/BookmarkNameFormatSetting.tsx
@@ -7,6 +7,8 @@ import { formatBookmarkName } from '@/hooks/Mapper/helpers/bookmarkFormatHelper'
 import { SignatureGroup, SignatureKind, SystemSignature } from '@/hooks/Mapper/types';
 import { MassState, TimeStatus } from '@/hooks/Mapper/types/connection';
 
+const EMPTY_MAPPING: Record<string, string> = {};
+
 const DUMMY_SIG_BASE: SystemSignature = {
   eve_id: 'ABC-123',
   name: 'ABC-123',
@@ -37,6 +39,8 @@ const VARIABLES = [
   { id: '{mass_status}', desc: 'Mass remaining (e.g., Destab, Crit)' },
   { id: '{temporary_name}', desc: 'Temporary name if set' },
   { id: '{description}', desc: 'Custom description' },
+  { id: '{direction}', desc: 'Wormhole direction (e.g., In, Out)' },
+  { id: '{spawn}', desc: 'Spawn type for outgoing wormholes (e.g., Static, Wandering)' },
 ];
 
 interface CustomMappingInputProps {
@@ -117,6 +121,17 @@ const MASS_OPTIONS = [
 
 const OTHER_OPTIONS = [{ key: 'chain_separator', label: 'Chain Separator', defaultVal: '' }];
 
+const DIRECTION_OPTIONS = [
+  { key: 'direction_outgoing', label: 'Outgoing', defaultVal: 'Out' },
+  { key: 'direction_incoming', label: 'Incoming (K162)', defaultVal: 'In' },
+];
+
+const SPAWN_OPTIONS = [
+  { key: 'spawn_static', label: 'Static', defaultVal: 'Static' },
+  { key: 'spawn_wandering', label: 'Wandering', defaultVal: 'Wandering' },
+  { key: 'spawn_k162', label: 'K162 (Incoming)', defaultVal: 'K162' },
+];
+
 const SIZE_OPTIONS = [
   { key: 'size_small', label: 'Small (Frigate)', defaultVal: 'S' },
   { key: 'size_medium', label: 'Medium', defaultVal: 'M' },
@@ -147,7 +162,7 @@ const CLASS_OPTIONS = [
 export const BookmarkNameFormatSetting = () => {
   const { settings, updateSetting } = useMapSettings();
   const formatStr = settings.bookmark_name_format || '';
-  const customMapping = settings.bookmark_custom_mapping || {};
+  const customMapping = settings.bookmark_custom_mapping || EMPTY_MAPPING;
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [localFormat, setLocalFormat] = useState(formatStr);
@@ -210,6 +225,8 @@ export const BookmarkNameFormatSetting = () => {
       localMapping,
       { preview_sys: [otherDummySig] },
       'preview_sys',
+      undefined,
+      ['V283'],
     );
   }, [localFormat, settings.bookmark_wormholes_start_at_zero, localMapping]);
 
@@ -338,6 +355,16 @@ export const BookmarkNameFormatSetting = () => {
             <div className="flex flex-col gap-2">
               <h5 className="text-stone-300 text-xs font-semibold uppercase tracking-wider">Other / Formatting</h5>
               <div className="flex flex-wrap gap-2">{renderCustomMappingInputs(OTHER_OPTIONS)}</div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <h5 className="text-stone-300 text-xs font-semibold uppercase tracking-wider">Direction</h5>
+              <div className="flex flex-wrap gap-2">{renderCustomMappingInputs(DIRECTION_OPTIONS)}</div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <h5 className="text-stone-300 text-xs font-semibold uppercase tracking-wider">Spawn Type</h5>
+              <div className="flex flex-wrap gap-2">{renderCustomMappingInputs(SPAWN_OPTIONS)}</div>
             </div>
 
             <div className="flex flex-col gap-2">

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/SignatureSettings.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/SignatureSettings.tsx
@@ -8,6 +8,7 @@ import { WdButton } from '@/hooks/Mapper/components/ui-kit';
 import { handleAutoBookmark } from '@/hooks/Mapper/helpers/bookmarkFormatHelper.ts';
 import { parseSignatureCustomInfo } from '@/hooks/Mapper/helpers/parseSignatureCustomInfo';
 import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
+import { getSystemStaticInfo } from '@/hooks/Mapper/mapRootProvider/hooks/useLoadSystemStatic';
 import { MassState, OutCommand, SignatureGroup, SystemSignature, TimeStatus } from '@/hooks/Mapper/types';
 import { Dialog } from 'primereact/dialog';
 import { InputText } from 'primereact/inputtext';
@@ -157,7 +158,7 @@ export const SignatureSettings = ({ systemId, show, onHide, signatureData }: Map
           targetSystemClassGroup,
           targetSystemUuid,
           targetSolarSystemIdStr,
-          currentSystem?.system_static_info?.statics,
+          getSystemStaticInfo(solarSystemIdStr)?.statics,
         );
         out = updatedSignature;
       }

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/SignatureSettings.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/SignatureSettings/SignatureSettings.tsx
@@ -157,6 +157,7 @@ export const SignatureSettings = ({ systemId, show, onHide, signatureData }: Map
           targetSystemClassGroup,
           targetSystemUuid,
           targetSolarSystemIdStr,
+          currentSystem?.system_static_info?.statics,
         );
         out = updatedSignature;
       }

--- a/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
+++ b/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
@@ -29,8 +29,9 @@ const getTimeStatusString = (status?: TimeStatus, mapping?: Record<string, strin
   }
 };
 
-const getDirectionString = (isIncoming: boolean, mapping?: Record<string, string>): string => {
-  if (isIncoming) {
+const getDirectionString = (signatureType: string | undefined, mapping?: Record<string, string>): string => {
+  if (!signatureType) return '';
+  if (signatureType === 'K162') {
     return mapping?.direction_incoming !== undefined ? mapping.direction_incoming : 'In';
   }
   return mapping?.direction_outgoing !== undefined ? mapping.direction_outgoing : 'Out';
@@ -384,8 +385,8 @@ export const formatBookmarkName = (
   // Replace {description} -> signature.description
   result = result.replace(/\{description\}/g, () => signature.description || '');
 
-  // Replace {direction} -> incoming (K162) or outgoing (all other types)
-  result = result.replace(/\{direction\}/g, () => getDirectionString(signature.type === 'K162', mapping));
+  // Replace {direction} -> incoming (K162), outgoing (other known types), or '' (unknown)
+  result = result.replace(/\{direction\}/g, () => getDirectionString(signature.type, mapping));
 
   // Replace {spawn_type} -> Static or Wandering for outgoing wormholes, or K162 for incoming
   result = result.replace(/\{spawn_type\}/g, () => getSpawnTypeString(signature.type, currentSystemStatics, mapping));

--- a/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
+++ b/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
@@ -46,7 +46,8 @@ const getSpawnTypeString = (
   if (signatureType === 'K162') {
     return mapping?.spawn_k162 !== undefined ? mapping.spawn_k162 : 'K162';
   }
-  if (currentSystemStatics?.includes(signatureType)) {
+  if (currentSystemStatics === undefined) return '';
+  if (currentSystemStatics.includes(signatureType)) {
     return mapping?.spawn_static !== undefined ? mapping.spawn_static : 'Static';
   }
   return mapping?.spawn_wandering !== undefined ? mapping.spawn_wandering : 'Wandering';

--- a/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
+++ b/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
@@ -382,8 +382,8 @@ export const formatBookmarkName = (
   // Replace {direction} -> incoming (K162) or outgoing (all other types)
   result = result.replace(/\{direction\}/g, () => getDirectionString(signature.type === 'K162', mapping));
 
-  // Replace {spawn} -> Static or Wandering for outgoing wormholes (empty for K162)
-  result = result.replace(/\{spawn\}/g, () => getSpawnTypeString(signature.type, currentSystemStatics, mapping));
+  // Replace {spawn_type} -> Static or Wandering for outgoing wormholes, or K162 for incoming
+  result = result.replace(/\{spawn_type\}/g, () => getSpawnTypeString(signature.type, currentSystemStatics, mapping));
 
   // Cleanup whitespace
   return result.trim().replace(/\s+/g, ' ');

--- a/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
+++ b/assets/js/hooks/Mapper/helpers/bookmarkFormatHelper.ts
@@ -30,6 +30,28 @@ const getTimeStatusString = (status?: TimeStatus, mapping?: Record<string, strin
   }
 };
 
+const getDirectionString = (isIncoming: boolean, mapping?: Record<string, string>): string => {
+  if (isIncoming) {
+    return mapping?.direction_incoming !== undefined ? mapping.direction_incoming : 'In';
+  }
+  return mapping?.direction_outgoing !== undefined ? mapping.direction_outgoing : 'Out';
+};
+
+const getSpawnTypeString = (
+  signatureType: string | undefined,
+  currentSystemStatics: string[] | undefined,
+  mapping?: Record<string, string>,
+): string => {
+  if (!signatureType) return '';
+  if (signatureType === 'K162') {
+    return mapping?.spawn_k162 !== undefined ? mapping.spawn_k162 : 'K162';
+  }
+  if (currentSystemStatics?.includes(signatureType)) {
+    return mapping?.spawn_static !== undefined ? mapping.spawn_static : 'Static';
+  }
+  return mapping?.spawn_wandering !== undefined ? mapping.spawn_wandering : 'Wandering';
+};
+
 const getMassStatusString = (status?: MassState, mapping?: Record<string, string>): string => {
   switch (status) {
     case MassState.normal:
@@ -173,6 +195,7 @@ export const formatBookmarkName = (
   systemSignatures?: Record<string, SystemSignature[]>,
   currentSystemId?: string,
   currentSolarSystemId?: string,
+  currentSystemStatics?: string[],
 ): string => {
   let result = formatStr;
   const info = parseSignatureCustomInfo(signature.custom_info);
@@ -356,6 +379,12 @@ export const formatBookmarkName = (
   // Replace {description} -> signature.description
   result = result.replace(/\{description\}/g, () => signature.description || '');
 
+  // Replace {direction} -> incoming (K162) or outgoing (all other types)
+  result = result.replace(/\{direction\}/g, () => getDirectionString(signature.type === 'K162', mapping));
+
+  // Replace {spawn} -> Static or Wandering for outgoing wormholes (empty for K162)
+  result = result.replace(/\{spawn\}/g, () => getSpawnTypeString(signature.type, currentSystemStatics, mapping));
+
   // Cleanup whitespace
   return result.trim().replace(/\s+/g, ' ');
 };
@@ -378,6 +407,7 @@ export const handleAutoBookmark = async (
   targetSystemClassGroup: string | null,
   targetSystemUuid?: string,
   targetSolarSystemId?: string,
+  currentSystemStatics?: string[],
 ): Promise<{ updatedSignature: SystemSignature; shouldUpdate: boolean }> => {
   let updatedSignature = signature;
   let shouldUpdate = false;
@@ -483,6 +513,7 @@ export const handleAutoBookmark = async (
       systemSignatures,
       currentSystemId,
       currentSolarSystemId,
+      currentSystemStatics,
     );
 
     // Run this synchronously to avoid clipboard issues if possible


### PR DESCRIPTION
Added two sets of template vars

1. Direction - indicating if a wormhole is incoming or outgoing
2. Spawn Type - Static, Wandering or K162
3. Fixed an issue where customMapping fell back to an inline {} when settings.bookmark_custom_mapping was unset

This plugs a gap in how we name wormholes.

<img width="598" height="391" alt="image" src="https://github.com/user-attachments/assets/30dbd0fd-2bad-42c2-b984-56fd6f31ab92" />
<img width="398" height="225" alt="image" src="https://github.com/user-attachments/assets/2b6b37ef-dd49-4855-9f46-2eb2996ecf45" />
