### PR TITLE
fix(db): add the missing foreign key on connection locks

### DIFF
--- a/lib/wanderer_app/api/map_connection.ex
+++ b/lib/wanderer_app/api/map_connection.ex
@@ -15,6 +15,12 @@ defmodule WandererApp.Api.MapConnection do
       # Critical index for list_connections query performance
       index [:map_id], name: "map_chain_v1_map_id_index"
     end
+
+    references do
+      # A deleted character releases its locks rather than taking the
+      # connections with it -- the connection outlives whoever locked it.
+      reference :locked_by, on_delete: :nilify
+    end
   end
 
   json_api do

--- a/priv/repo/migrations/20260808152615_add_map_connection_locked_by_fk.exs
+++ b/priv/repo/migrations/20260808152615_add_map_connection_locked_by_fk.exs
@@ -1,0 +1,48 @@
+defmodule WandererApp.Repo.Migrations.AddMapConnectionLockedByFk do
+  @moduledoc """
+  Adds the missing foreign key on `map_chain_v1.locked_by_id`.
+
+  20260425000000 added the column as a bare `:binary_id` with no constraint,
+  while `MapConnection` declares `belongs_to :locked_by, Character`. The
+  resource therefore promised a relationship the database never enforced, and
+  because no snapshot was regenerated at the time, every subsequent
+  `mix ash_postgres.generate_migrations` run wanted to re-add both
+  `locked_by_id` and `locked_at` from scratch.
+
+  This migration adds only the constraint -- the columns already exist -- and
+  regenerates the snapshot so codegen stops proposing that duplicate.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    # Character has a plain :destroy action and the column has never been
+    # constrained, so rows may point at characters that no longer exist.
+    # Those would abort the ALTER below, so release their locks first: a lock
+    # held by a deleted character is already meaningless.
+    execute("""
+    UPDATE map_chain_v1
+       SET locked_by_id = NULL
+     WHERE locked_by_id IS NOT NULL
+       AND NOT EXISTS (SELECT 1 FROM character_v1 WHERE character_v1.id = map_chain_v1.locked_by_id)
+    """)
+
+    alter table(:map_chain_v1) do
+      modify :locked_by_id,
+             references(:character_v1,
+               column: :id,
+               name: "map_chain_v1_locked_by_id_fkey",
+               type: :uuid,
+               on_delete: :nilify_all
+             )
+    end
+  end
+
+  # Deliberately not a mirror image of up/0. The columns predate this
+  # migration, so dropping them on rollback would destroy data this migration
+  # never created; only the constraint comes off. Locks released from deleted
+  # characters stay released -- there is nothing valid to restore them to.
+  def down do
+    drop_if_exists constraint(:map_chain_v1, "map_chain_v1_locked_by_id_fkey")
+  end
+end

--- a/priv/resource_snapshots/repo/map_chain_v1/20260808152615.json
+++ b/priv/resource_snapshots/repo/map_chain_v1/20260808152615.json
@@ -1,0 +1,272 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"gen_random_uuid()\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "solar_system_source",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "solar_system_target",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "0",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "mass_status",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "0",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "time_status",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "2",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "ship_size_type",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "0",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "type",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "wormhole_type",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "0",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "count_of_passage",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "locked",
+      "type": "boolean"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "locked_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "custom_info",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "inserted_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "updated_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "map_chain_v1_map_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": null,
+        "table": "maps_v1"
+      },
+      "scale": null,
+      "size": null,
+      "source": "map_id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "map_chain_v1_locked_by_id_fkey",
+        "on_delete": "nilify",
+        "on_update": null,
+        "primary_key?": true,
+        "schema": null,
+        "table": "character_v1"
+      },
+      "scale": null,
+      "size": null,
+      "source": "locked_by_id",
+      "type": "uuid"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "custom_indexes": [
+    {
+      "all_tenants?": false,
+      "concurrently": false,
+      "error_fields": [
+        "map_id"
+      ],
+      "fields": [
+        {
+          "type": "atom",
+          "value": "map_id"
+        }
+      ],
+      "include": null,
+      "message": null,
+      "name": "map_chain_v1_map_id_index",
+      "nulls_distinct": true,
+      "prefix": null,
+      "table": null,
+      "unique": false,
+      "using": null,
+      "where": null
+    }
+  ],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "99281EAB451DBB2C9D2435ABE8A2496C28AA711C8B3EBE196C96D8E075A05425",
+  "identities": [],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.WandererApp.Repo",
+  "schema": null,
+  "table": "map_chain_v1"
+}


### PR DESCRIPTION
The column that records who locked a connection has no foreign key, so deleting a character can leave connections pointing at a character that no longer exists. This adds the constraint and clears any stale values.

@DmitryPopov @DanSylvest

