### PR TITLE
ci: report when Ash resources and their snapshots disagree

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,22 @@ jobs:
           fi
         continue-on-error: true
 
+      # Advisory, like the other checks here. Catches resource definitions that
+      # have drifted from priv/resource_snapshots — usually after a dependency
+      # bump changes how a default is serialized, which is otherwise invisible
+      # until someone runs `mix ash.codegen` locally and gets an unrelated diff.
+      - name: Check Ash codegen is up to date
+        id: codegen
+        run: |
+          if mix ash.codegen --check; then
+            echo "status=✅ Up to date" >> $GITHUB_OUTPUT
+            echo "count=0" >> $GITHUB_OUTPUT
+          else
+            echo "status=❌ Pending changes" >> $GITHUB_OUTPUT
+            echo "count=1" >> $GITHUB_OUTPUT
+          fi
+        continue-on-error: true
+
       - name: Compile code and capture warnings
         id: compile
         run: |
@@ -279,6 +295,7 @@ jobs:
             | Category | Status | Count | Details |
             |----------|---------|-------|---------|
             | 📝 **Code Formatting** | ${{ steps.format.outputs.status }} | ${{ steps.format.outputs.count }} issues | `mix format --check-formatted` |
+            | 🧬 **Ash Codegen** | ${{ steps.codegen.outputs.status }} | ${{ steps.codegen.outputs.count }} pending | `mix ash.codegen --check` |
             | 🔨 **Compilation** | ${{ steps.compile.outputs.status }} | ${{ steps.compile.outputs.warnings }} warnings | `mix compile` |
             | 🧪 **Tests** | ${{ steps.tests.outputs.status }} | ${{ steps.tests.outputs.failures }}/${{ steps.tests.outputs.total }} failed | Success rate: ${{ steps.tests.outputs.success_rate }}% |
             | 📊 **Coverage** | ${{ steps.coverage.outputs.status }} | ${{ steps.coverage.outputs.percentage }}% | `mix coveralls` |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,22 +72,6 @@ jobs:
           fi
         continue-on-error: true
 
-      # Advisory, like the other checks here. Catches resource definitions that
-      # have drifted from priv/resource_snapshots — usually after a dependency
-      # bump changes how a default is serialized, which is otherwise invisible
-      # until someone runs `mix ash.codegen` locally and gets an unrelated diff.
-      - name: Check Ash codegen is up to date
-        id: codegen
-        run: |
-          if mix ash.codegen --check; then
-            echo "status=✅ Up to date" >> $GITHUB_OUTPUT
-            echo "count=0" >> $GITHUB_OUTPUT
-          else
-            echo "status=❌ Pending changes" >> $GITHUB_OUTPUT
-            echo "count=1" >> $GITHUB_OUTPUT
-          fi
-        continue-on-error: true
-
       - name: Compile code and capture warnings
         id: compile
         run: |
@@ -109,6 +93,42 @@ jobs:
           echo "output<<EOF" >> $GITHUB_OUTPUT
           echo "$output" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+        continue-on-error: true
+
+      # Advisory, like the other checks here. Catches resource definitions that
+      # have drifted from priv/resource_snapshots — usually after a dependency
+      # bump changes how a default is serialized, which is otherwise invisible
+      # until someone runs `mix ash.codegen` locally and gets an unrelated diff.
+      #
+      # Runs after the compile step on purpose: `mix ash.codegen` compiles first,
+      # so on a branch that doesn't build it would fail here and report a
+      # codegen-drift verdict for what is really a compile error.
+      - name: Check Ash codegen is up to date
+        id: codegen
+        run: |
+          # Capture codegen output
+          if output=$(mix ash.codegen --check 2>&1); then
+            echo "status=✅ Up to date" >> $GITHUB_OUTPUT
+            echo "count=0" >> $GITHUB_OUTPUT
+            echo "details=" >> $GITHUB_OUTPUT
+          else
+            echo "status=❌ Pending changes" >> $GITHUB_OUTPUT
+            echo "count=1" >> $GITHUB_OUTPUT
+
+            # Surface the drift in the PR comment; bounded so a large diff
+            # cannot blow out the comment body.
+            echo "details<<EOF" >> $GITHUB_OUTPUT
+            echo "<details>" >> $GITHUB_OUTPUT
+            echo "<summary>🧬 Pending Ash codegen changes</summary>" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo '```' >> $GITHUB_OUTPUT
+            echo "$output" | tail -n 40 >> $GITHUB_OUTPUT
+            echo '```' >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "Run \`mix ash.codegen <name>\` locally and commit the result." >> $GITHUB_OUTPUT
+            echo "</details>" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
         continue-on-error: true
 
       - name: Setup database
@@ -253,6 +273,10 @@ jobs:
           credo_score=$(echo "scale=0; (100 - ${{ steps.credo.outputs.total_issues }} * 2)" | bc | sed 's/^-.*$/0/')
           dialyzer_score=$(echo "scale=0; (100 - ${{ steps.dialyzer.outputs.warnings }} * 2 - ${{ steps.dialyzer.outputs.errors }} * 10)" | bc | sed 's/^-.*$/0/')
 
+          # Note: the Ash codegen drift row is reported in the metrics table but
+          # deliberately left out of this score — `main` is currently drifted, so
+          # including it would permanently depress every PR's score. Add it as a
+          # term once `main` is clean.
           overall_score=$(echo "scale=1; ($format_score + $compile_score + $test_score + $coverage_score + $credo_score + $dialyzer_score) / 6" | bc)
 
           echo "overall_score=$overall_score" >> $GITHUB_OUTPUT
@@ -310,6 +334,8 @@ jobs:
             - **Dialyzer Warnings**: ${{ steps.dialyzer.outputs.warnings }}/161 (limit: 161)
             - **Test Coverage**: ${{ steps.coverage.outputs.percentage }}%/50% (minimum: 50%)
             - **Test Failures**: ${{ steps.tests.outputs.failures }}/0 (limit: 0)
+
+            ${{ steps.codegen.outputs.details }}
 
             <details>
             <summary>📈 Progress Toward Goals</summary>


### PR DESCRIPTION
Resource definitions can drift from their stored snapshots without anything failing, which later shows up as a surprise or colliding migration. CI now reports the drift in the test results comment; it does not block merging.

@DmitryPopov @DanSylvest

