### PR TITLE
refactor(map): move the wormhole class list into one module

### DIFF
--- a/lib/wanderer_app/map/server/map_server_connections_impl.ex
+++ b/lib/wanderer_app/map/server/map_server_connections_impl.ex
@@ -19,13 +19,9 @@ defmodule WandererApp.Map.Server.ConnectionsImpl do
   @ns 9
   # @ccp2 10
   # @ccp3 11
-  @thera 12
+  # Classes 12 and 14-18 (Thera and the drifter systems) are not named here:
+  # WandererApp.SystemClass owns the canonical wormhole class list.
   @c13 13
-  @sentinel 14
-  @barbican 15
-  @vidette 16
-  @conflux 17
-  @redoubt 18
   @a1 19
   @a2 20
   @a3 21
@@ -40,21 +36,9 @@ defmodule WandererApp.Map.Server.ConnectionsImpl do
 
   @jita 30_000_142
 
-  @wh_space [
-    @c1,
-    @c2,
-    @c3,
-    @c4,
-    @c5,
-    @c6,
-    @c13,
-    @thera,
-    @sentinel,
-    @barbican,
-    @vidette,
-    @conflux,
-    @redoubt
-  ]
+  # Derived, not restated: WandererApp.SystemClass owns the canonical list so
+  # consumers of the classification cannot drift apart.
+  @wh_space WandererApp.SystemClass.wormhole_classes()
 
   @known_space [@hs, @ls, @ns, @pochven]
 

--- a/lib/wanderer_app/system_class.ex
+++ b/lib/wanderer_app/system_class.ex
@@ -54,10 +54,11 @@ defmodule WandererApp.SystemClass do
 
   @doc """
   Resolves a solar system id to its class and reports whether it is wormhole
-  space. Returns false when static info cannot be resolved.
+  space. Returns false when static info cannot be resolved, and for any
+  non-integer input (callers pass ids straight from external payloads).
   """
-  @spec wormhole_system?(integer()) :: boolean()
-  def wormhole_system?(solar_system_id) do
+  @spec wormhole_system?(term()) :: boolean()
+  def wormhole_system?(solar_system_id) when is_integer(solar_system_id) do
     case WandererApp.CachedInfo.get_system_static_info(solar_system_id) do
       {:ok, %{system_class: class}} ->
         wormhole?(class)
@@ -69,5 +70,13 @@ defmodule WandererApp.SystemClass do
 
         false
     end
+  end
+
+  def wormhole_system?(solar_system_id) do
+    Logger.warning(
+      "[SystemClass] wormhole_system?/1 expects an integer solar system id, got: #{inspect(solar_system_id)}"
+    )
+
+    false
   end
 end

--- a/lib/wanderer_app/system_class.ex
+++ b/lib/wanderer_app/system_class.ex
@@ -1,0 +1,73 @@
+defmodule WandererApp.SystemClass do
+  @moduledoc """
+  Canonical wormhole classification for EVE solar systems.
+
+  Single source of truth for "is this class wormhole space", so callers needing
+  the classification derive it from here rather than restating the list. Mirrors
+  `assets/js/hooks/Mapper/components/map/helpers/isWormholeSpace.ts`.
+  """
+
+  require Logger
+
+  @c1 1
+  @c2 2
+  @c3 3
+  @c4 4
+  @c5 5
+  @c6 6
+  @thera 12
+  @c13 13
+  @sentinel 14
+  @barbican 15
+  @vidette 16
+  @conflux 17
+  @redoubt 18
+
+  # c1-c6, Thera, c13 shattered frigate holes, and the five drifter systems.
+  @wormhole_classes [
+    @c1,
+    @c2,
+    @c3,
+    @c4,
+    @c5,
+    @c6,
+    @c13,
+    @thera,
+    @sentinel,
+    @barbican,
+    @vidette,
+    @conflux,
+    @redoubt
+  ]
+
+  @doc """
+  The wormhole class ids. Exposed so callers needing a compile-time list (for
+  `in` checks in guards or hot paths) can derive theirs from this one rather
+  than restating it.
+  """
+  @spec wormhole_classes() :: [pos_integer()]
+  def wormhole_classes, do: @wormhole_classes
+
+  @spec wormhole?(integer() | nil) :: boolean()
+  def wormhole?(class) when class in @wormhole_classes, do: true
+  def wormhole?(_), do: false
+
+  @doc """
+  Resolves a solar system id to its class and reports whether it is wormhole
+  space. Returns false when static info cannot be resolved.
+  """
+  @spec wormhole_system?(integer()) :: boolean()
+  def wormhole_system?(solar_system_id) do
+    case WandererApp.CachedInfo.get_system_static_info(solar_system_id) do
+      {:ok, %{system_class: class}} ->
+        wormhole?(class)
+
+      other ->
+        Logger.warning(
+          "[SystemClass] could not resolve static info for #{inspect(solar_system_id)}: #{inspect(other)}"
+        )
+
+        false
+    end
+  end
+end

--- a/test/unit/system_class_test.exs
+++ b/test/unit/system_class_test.exs
@@ -1,5 +1,7 @@
 defmodule WandererApp.SystemClassTest do
-  use ExUnit.Case, async: true
+  # `wormhole_system?/1` resolves static info via `CachedInfo`, which hits the
+  # DB-backed cache, so this needs sandbox access rather than plain ExUnit.Case.
+  use WandererApp.DataCase, async: true
 
   alias WandererApp.SystemClass
 
@@ -35,6 +37,38 @@ defmodule WandererApp.SystemClassTest do
     test "returns false for nil and unknown classes" do
       refute SystemClass.wormhole?(nil)
       refute SystemClass.wormhole?(999)
+    end
+  end
+
+  describe "wormhole_classes/0" do
+    test "returns the exact canonical set" do
+      assert Enum.sort(SystemClass.wormhole_classes()) == [
+               1,
+               2,
+               3,
+               4,
+               5,
+               6,
+               12,
+               13,
+               14,
+               15,
+               16,
+               17,
+               18
+             ]
+    end
+  end
+
+  describe "wormhole_system?/1" do
+    test "returns false for non-integer input" do
+      refute SystemClass.wormhole_system?("31000005")
+      refute SystemClass.wormhole_system?(:not_an_id)
+      refute SystemClass.wormhole_system?(nil)
+    end
+
+    test "returns false for an unresolvable solar system id" do
+      refute SystemClass.wormhole_system?(-1)
     end
   end
 end

--- a/test/unit/system_class_test.exs
+++ b/test/unit/system_class_test.exs
@@ -1,0 +1,40 @@
+defmodule WandererApp.SystemClassTest do
+  use ExUnit.Case, async: true
+
+  alias WandererApp.SystemClass
+
+  describe "wormhole?/1" do
+    test "returns true for c1-c6" do
+      for class <- 1..6 do
+        assert SystemClass.wormhole?(class), "class #{class} should be wormhole"
+      end
+    end
+
+    test "returns true for thera and c13" do
+      assert SystemClass.wormhole?(12)
+      assert SystemClass.wormhole?(13)
+    end
+
+    test "returns true for drifter holes" do
+      for class <- 14..18 do
+        assert SystemClass.wormhole?(class), "class #{class} should be wormhole"
+      end
+    end
+
+    test "returns false for known space" do
+      refute SystemClass.wormhole?(7)
+      refute SystemClass.wormhole?(8)
+      refute SystemClass.wormhole?(9)
+    end
+
+    test "returns false for pochven and zarzakh" do
+      refute SystemClass.wormhole?(25)
+      refute SystemClass.wormhole?(10_100)
+    end
+
+    test "returns false for nil and unknown classes" do
+      refute SystemClass.wormhole?(nil)
+      refute SystemClass.wormhole?(999)
+    end
+  end
+end


### PR DESCRIPTION
The list of wormhole system classes was written inline in the connection code, and a second feature needs the same list. It now lives in one module with helpers, and behaviour is unchanged.

First of the stack #651 → #652 → #653 → #654, but useful on its own.

@DmitryPopov @DanSylvest

