### PR TITLE
Map export and import

### DIFF
--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/ImportExport.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/ImportExport.tsx
@@ -1,5 +1,5 @@
 import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { Toast } from 'primereact/toast';
 import { parseMapUserSettings } from '@/hooks/Mapper/components/helpers';
 import { saveTextFile } from '@/hooks/Mapper/utils/saveToFile.ts';
@@ -7,14 +7,18 @@ import { SplitButton } from 'primereact/splitbutton';
 import { loadTextFile } from '@/hooks/Mapper/utils';
 import { applyMigrations } from '@/hooks/Mapper/mapRootProvider/migrations';
 import { createDefaultStoredSettings } from '@/hooks/Mapper/mapRootProvider/helpers/createDefaultStoredSettings.ts';
+import { OutCommand } from '@/hooks/Mapper/types';
+import { WdButton } from '@/hooks/Mapper/components/ui-kit';
 
 export const ImportExport = () => {
   const {
     storedSettings: { getSettingsForExport, applySettings },
     data: { map_slug },
+    outCommand,
   } = useMapRootState();
 
   const toast = useRef<Toast | null>(null);
+  const [mapDataBusy, setMapDataBusy] = useState(false);
 
   const handleImportFromClipboard = useCallback(async () => {
     const text = await navigator.clipboard.readText();
@@ -143,6 +147,90 @@ export const ImportExport = () => {
     }
   }, [getSettingsForExport, map_slug]);
 
+  const handleExportMapData = useCallback(async () => {
+    setMapDataBusy(true);
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const res: any = await outCommand({ type: OutCommand.exportMapData, data: null });
+
+      if (!res?.data) {
+        throw new Error(res?.error ?? 'Empty response');
+      }
+
+      const { systems = [], connections = [], signatures = [] } = res.data;
+
+      saveTextFile(`map_${map_slug}_${new Date().toISOString().slice(0, 10)}.json`, JSON.stringify(res.data, null, 2));
+
+      toast.current?.show({
+        severity: 'success',
+        summary: 'Export map',
+        detail: `Saved ${systems.length} systems, ${connections.length} connections, ${signatures.length} signatures.`,
+        life: 4000,
+      });
+    } catch (error) {
+      console.error('Export map data Error: ', error);
+
+      toast.current?.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Some error occurred on exporting map data, check console log.',
+        life: 3000,
+      });
+    } finally {
+      setMapDataBusy(false);
+    }
+  }, [outCommand, map_slug]);
+
+  const handleImportMapData = useCallback(async () => {
+    let parsed;
+
+    try {
+      parsed = JSON.parse(await loadTextFile());
+    } catch (error) {
+      console.error('Import map data Error: ', error);
+
+      toast.current?.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Selected file is not a valid map export.',
+        life: 3000,
+      });
+      return;
+    }
+
+    setMapDataBusy(true);
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const res: any = await outCommand({ type: OutCommand.importMapData, data: { data: parsed } });
+
+      if (!res?.result) {
+        throw new Error(res?.error ?? 'Empty response');
+      }
+
+      const { systems, connections, signatures } = res.result;
+
+      toast.current?.show({
+        severity: 'success',
+        summary: 'Import map',
+        detail: `Added ${systems} systems, ${connections} connections, ${signatures} signatures.`,
+        life: 4000,
+      });
+    } catch (error) {
+      console.error('Import map data Error: ', error);
+
+      toast.current?.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Some error occurred on importing map data, check console log.',
+        life: 3000,
+      });
+    } finally {
+      setMapDataBusy(false);
+    }
+  }, [outCommand]);
+
   const importItems = useMemo(
     () => [
       {
@@ -198,6 +286,35 @@ export const ImportExport = () => {
         </div>
 
         <span className="text-stone-500 text-[12px]">*Will save map settings to clipboard.</span>
+      </div>
+
+      <div className="border-b-2 border-dotted border-stone-700/50 h-px" />
+
+      <div className="flex flex-col gap-1">
+        <div className="flex gap-2">
+          <WdButton
+            onClick={handleExportMapData}
+            icon="pi pi-cloud-download"
+            size="small"
+            label="Export map"
+            className="py-[4px]"
+            disabled={mapDataBusy}
+          />
+          <WdButton
+            onClick={handleImportMapData}
+            icon="pi pi-cloud-upload"
+            size="small"
+            severity="warning"
+            label="Import map"
+            className="py-[4px]"
+            disabled={mapDataBusy}
+          />
+        </div>
+
+        <span className="text-stone-500 text-[12px]">
+          *Map contents - systems, connections and signatures - as a file. Import adds what is missing, systems already
+          on the map are left untouched.
+        </span>
       </div>
 
       <Toast ref={toast} />

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/ImportExport.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/ImportExport.tsx
@@ -9,6 +9,16 @@ import { applyMigrations } from '@/hooks/Mapper/mapRootProvider/migrations';
 import { createDefaultStoredSettings } from '@/hooks/Mapper/mapRootProvider/helpers/createDefaultStoredSettings.ts';
 import { OutCommand } from '@/hooks/Mapper/types';
 import { WdButton } from '@/hooks/Mapper/components/ui-kit';
+import { Dialog } from 'primereact/dialog';
+import { WdCheckbox } from '@/hooks/Mapper/components/ui-kit/WdCheckbox';
+
+type PendingImport = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  document: any;
+  systems: number;
+  connections: number;
+  signatures: number;
+};
 
 export const ImportExport = () => {
   const {
@@ -19,6 +29,8 @@ export const ImportExport = () => {
 
   const toast = useRef<Toast | null>(null);
   const [mapDataBusy, setMapDataBusy] = useState(false);
+  const [includeSignatures, setIncludeSignatures] = useState(true);
+  const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
 
   const handleImportFromClipboard = useCallback(async () => {
     const text = await navigator.clipboard.readText();
@@ -152,7 +164,10 @@ export const ImportExport = () => {
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const res: any = await outCommand({ type: OutCommand.exportMapData, data: null });
+      const res: any = await outCommand({
+        type: OutCommand.exportMapData,
+        data: { include_signatures: includeSignatures },
+      });
 
       if (!res?.data) {
         throw new Error(res?.error ?? 'Empty response');
@@ -180,7 +195,7 @@ export const ImportExport = () => {
     } finally {
       setMapDataBusy(false);
     }
-  }, [outCommand, map_slug]);
+  }, [includeSignatures, outCommand, map_slug]);
 
   const handleImportMapData = useCallback(async () => {
     let parsed;
@@ -199,11 +214,31 @@ export const ImportExport = () => {
       return;
     }
 
+    // the map is shared and an import cannot be undone, so the counts get confirmed first
+    setPendingImport({
+      document: parsed,
+      systems: Array.isArray(parsed?.systems) ? parsed.systems.length : 0,
+      connections: Array.isArray(parsed?.connections) ? parsed.connections.length : 0,
+      signatures: Array.isArray(parsed?.signatures) ? parsed.signatures.length : 0,
+    });
+  }, []);
+
+  const handleConfirmImport = useCallback(async () => {
+    if (!pendingImport) {
+      return;
+    }
+
+    const { document } = pendingImport;
+
+    setPendingImport(null);
     setMapDataBusy(true);
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const res: any = await outCommand({ type: OutCommand.importMapData, data: { data: parsed } });
+      const res: any = await outCommand({
+        type: OutCommand.importMapData,
+        data: { data: document, include_signatures: includeSignatures },
+      });
 
       if (!res?.result) {
         throw new Error(res?.error ?? 'Empty response');
@@ -214,7 +249,10 @@ export const ImportExport = () => {
       toast.current?.show({
         severity: 'success',
         summary: 'Import map',
-        detail: `Added ${systems} systems, ${connections} connections, ${signatures} signatures.`,
+        detail:
+          systems + connections + signatures === 0
+            ? 'Everything in that file was already on the map - nothing was added.'
+            : `Added ${systems} systems, ${connections} connections, ${signatures} signatures.`,
         life: 4000,
       });
     } catch (error) {
@@ -229,7 +267,7 @@ export const ImportExport = () => {
     } finally {
       setMapDataBusy(false);
     }
-  }, [outCommand]);
+  }, [includeSignatures, outCommand, pendingImport]);
 
   const importItems = useMemo(
     () => [
@@ -311,11 +349,38 @@ export const ImportExport = () => {
           />
         </div>
 
+        <WdCheckbox
+          label="Include signatures"
+          value={includeSignatures}
+          onChange={e => setIncludeSignatures(!!e.checked)}
+        />
+
         <span className="text-stone-500 text-[12px]">
           *Map contents - systems, connections and signatures - as a file. Import adds what is missing, systems already
           on the map are left untouched.
         </span>
       </div>
+
+      <Dialog
+        header="Import map"
+        visible={pendingImport != null}
+        draggable={false}
+        className="w-[420px]"
+        onHide={() => setPendingImport(null)}
+      >
+        <div className="flex flex-col gap-3">
+          <span className="text-stone-200 text-[13px]">
+            This adds up to {pendingImport?.systems} systems, {pendingImport?.connections} connections and{' '}
+            {includeSignatures ? pendingImport?.signatures : 0} signatures to <b>{map_slug ?? 'this map'}</b>, for
+            everyone on the map. Systems already there are left alone, and an import cannot be undone.
+          </span>
+
+          <div className="flex justify-end gap-2">
+            <WdButton size="small" outlined label="Cancel" onClick={() => setPendingImport(null)} />
+            <WdButton size="small" severity="warning" label="Import" onClick={handleConfirmImport} />
+          </div>
+        </div>
+      </Dialog>
 
       <Toast ref={toast} />
     </div>

--- a/assets/js/hooks/Mapper/types/mapHandlers.ts
+++ b/assets/js/hooks/Mapper/types/mapHandlers.ts
@@ -296,6 +296,8 @@ export enum OutCommand {
   showActivity = 'show_activity',
   showTracking = 'show_tracking',
   getUserSettings = 'get_user_settings',
+  exportMapData = 'export_map_data',
+  importMapData = 'import_map_data',
   updateUserSettings = 'update_user_settings',
   saveDefaultSettings = 'save_default_settings',
   getDefaultSettings = 'get_default_settings',

--- a/lib/wanderer_app/api/map_system_signature.ex
+++ b/lib/wanderer_app/api/map_system_signature.ex
@@ -58,6 +58,8 @@ defmodule WandererApp.Api.MapSystemSignature do
     define(:by_system_id, action: :by_system_id, args: [:system_id])
     define(:by_system_id_all, action: :by_system_id_all, args: [:system_id])
 
+    define(:by_system_ids, action: :by_system_ids, args: [:system_ids])
+
     define(:by_system_id_and_eve_ids,
       action: :by_system_id_and_eve_ids,
       args: [:system_id, :eve_ids]
@@ -173,6 +175,12 @@ defmodule WandererApp.Api.MapSystemSignature do
     read :by_system_id_all do
       argument(:system_id, :string, allow_nil?: false)
       filter(expr(system_id == ^arg(:system_id)))
+    end
+
+    read :by_system_ids do
+      argument(:system_ids, {:array, :string}, allow_nil?: false)
+
+      filter(expr(system_id in ^arg(:system_ids)))
     end
 
     read :by_system_id_and_eve_ids do

--- a/lib/wanderer_app/map/operations/transfer.ex
+++ b/lib/wanderer_app/map/operations/transfer.ex
@@ -19,7 +19,11 @@ defmodule WandererApp.Map.Operations.Transfer do
 
   @export_version 1
 
-  @type stats :: %{systems: non_neg_integer(), connections: non_neg_integer(), signatures: non_neg_integer()}
+  @type stats :: %{
+          systems: non_neg_integer(),
+          connections: non_neg_integer(),
+          signatures: non_neg_integer()
+        }
 
   @doc """
   Builds the export document for a map.
@@ -79,7 +83,7 @@ defmodule WandererApp.Map.Operations.Transfer do
       |> Enum.count(& &1)
 
     imported_connections = import_connections(map_id, connections, user_id, character_id)
-    imported_signatures = import_signatures(map_id, signatures)
+    imported_signatures = import_signatures(map_id, signatures, character_id)
 
     Logger.info(
       "Imported #{imported_systems} systems, #{imported_connections} connections, " <>
@@ -132,24 +136,23 @@ defmodule WandererApp.Map.Operations.Transfer do
   defp export_signatures(_systems, false), do: []
 
   defp export_signatures(systems, true) do
-    Enum.flat_map(systems, fn system ->
-      case MapSystemSignature.by_system_id_all(%{system_id: system.id}) do
-        {:ok, signatures} ->
-          signatures
-          |> Enum.reject(& &1.deleted)
-          |> Enum.map(&export_signature(&1, system.solar_system_id))
+    solar_system_ids = Map.new(systems, &{&1.id, &1.solar_system_id})
 
-        {:error, _} ->
-          []
-      end
-    end)
+    case MapSystemSignature.by_system_ids(Map.keys(solar_system_ids)) do
+      {:ok, signatures} ->
+        signatures
+        |> Enum.reject(& &1.deleted)
+        |> Enum.map(&export_signature(&1, Map.fetch!(solar_system_ids, &1.system_id)))
+
+      {:error, _} ->
+        []
+    end
   end
 
   defp export_signature(signature, solar_system_id) do
     %{
       "solar_system_id" => solar_system_id,
       "eve_id" => signature.eve_id,
-      "character_eve_id" => signature.character_eve_id,
       "name" => signature.name,
       "temporary_name" => signature.temporary_name,
       "description" => signature.description,
@@ -162,8 +165,11 @@ defmodule WandererApp.Map.Operations.Transfer do
 
   # -- import helpers ------------------------------------------------------------------------
 
+  # Deletion on a map is a soft `visible: false`, and `Server.add_system` decides a system is
+  # missing on exactly that basis. Counting the hidden rows as present would let a deleted system
+  # come back stripped of everything the document carries for it.
   defp existing_solar_system_ids(map_id) do
-    case WandererApp.MapSystemRepo.get_all_by_map(map_id) do
+    case WandererApp.MapSystemRepo.get_visible_by_map(map_id) do
       {:ok, systems} -> MapSet.new(systems, & &1.solar_system_id)
       _ -> MapSet.new()
     end
@@ -215,6 +221,8 @@ defmodule WandererApp.Map.Operations.Transfer do
   end
 
   defp import_connections(map_id, connections, user_id, character_id) do
+    existing_pairs = existing_connection_pairs(map_id)
+
     paste_payload =
       connections
       |> Enum.filter(&is_map/1)
@@ -223,7 +231,14 @@ defmodule WandererApp.Map.Operations.Transfer do
              {:ok, target} <- parse_solar_system_id(connection["target"]) do
           [
             connection
-            |> Map.take(["type", "mass_status", "time_status", "ship_size_type", "wormhole_type", "locked"])
+            |> Map.take([
+              "type",
+              "mass_status",
+              "time_status",
+              "ship_size_type",
+              "wormhole_type",
+              "locked"
+            ])
             |> Map.merge(%{"source" => to_string(source), "target" => to_string(target)})
           ]
         else
@@ -233,10 +248,32 @@ defmodule WandererApp.Map.Operations.Transfer do
 
     Server.paste_connections(map_id, paste_payload, user_id, character_id)
 
-    length(paste_payload)
+    # the payload is everything the document had; only the pairs the map did not already carry
+    # are new, and a document may well name the same pair twice
+    paste_payload
+    |> Enum.map(&connection_pair(&1["source"], &1["target"]))
+    |> Enum.uniq()
+    |> Enum.count(&(not MapSet.member?(existing_pairs, &1)))
   end
 
-  defp import_signatures(map_id, signatures) do
+  defp existing_connection_pairs(map_id) do
+    case WandererApp.MapConnectionRepo.get_by_map(map_id) do
+      {:ok, connections} ->
+        MapSet.new(connections, &connection_pair(&1.solar_system_source, &1.solar_system_target))
+
+      _ ->
+        MapSet.new()
+    end
+  end
+
+  # a connection is the same connection whichever end the document names first
+  defp connection_pair(source, target) do
+    [to_string(source), to_string(target)] |> Enum.sort() |> List.to_tuple()
+  end
+
+  defp import_signatures(map_id, signatures, character_id) do
+    character_eve_id = importing_character_eve_id(character_id)
+
     signatures
     |> Enum.filter(&is_map/1)
     |> Enum.group_by(& &1["solar_system_id"])
@@ -244,20 +281,23 @@ defmodule WandererApp.Map.Operations.Transfer do
       with {:ok, parsed_id} <- parse_solar_system_id(solar_system_id),
            {:ok, system} when not is_nil(system) <-
              WandererApp.MapSystemRepo.get_by_map_and_solar_system_id(map_id, parsed_id) do
-        acc + create_signatures(system.id, system_signatures)
+        acc + create_signatures(system.id, system_signatures, character_eve_id)
       else
         _ -> acc
       end
     end)
   end
 
-  defp create_signatures(system_id, signatures) do
+  # `create` upserts on (system_id, eve_id), so a signature the target already has comes back
+  # {:ok, _} without anything having been added. Only the ones that were not there are new.
+  defp create_signatures(system_id, signatures, character_eve_id) do
+    existing_eve_ids = existing_signature_eve_ids(system_id, signatures)
+
     Enum.count(signatures, fn signature ->
       attrs =
         signature
         |> Map.take([
           "eve_id",
-          "character_eve_id",
           "name",
           "temporary_name",
           "description",
@@ -268,16 +308,35 @@ defmodule WandererApp.Map.Operations.Transfer do
         ])
         |> Map.new(fn {key, value} -> {String.to_existing_atom(key), value} end)
         |> Map.put(:system_id, system_id)
+        |> Map.put(:character_eve_id, character_eve_id)
 
       case MapSystemSignature.create(attrs) do
         {:ok, _} ->
-          true
+          not MapSet.member?(existing_eve_ids, to_string(signature["eve_id"]))
 
         {:error, reason} ->
           Logger.warning("[Transfer] skipped signature: #{inspect(reason)}")
           false
       end
     end)
+  end
+
+  defp existing_signature_eve_ids(system_id, signatures) do
+    eve_ids = signatures |> Enum.map(&to_string(&1["eve_id"])) |> Enum.uniq()
+
+    case MapSystemSignature.by_system_id_and_eve_ids(system_id, eve_ids) do
+      {:ok, existing} -> MapSet.new(existing, &to_string(&1.eve_id))
+      _ -> MapSet.new()
+    end
+  end
+
+  # `character_eve_id` is required on a signature, and the character who scanned it on the
+  # exporting side means nothing here - the import is attributed to whoever ran it.
+  defp importing_character_eve_id(character_id) do
+    case WandererApp.Character.get_character(character_id) do
+      {:ok, %{eve_id: eve_id}} when not is_nil(eve_id) -> to_string(eve_id)
+      _ -> "0"
+    end
   end
 
   defp position(%{"x" => x, "y" => y}) when is_number(x) and is_number(y),

--- a/lib/wanderer_app/map/operations/transfer.ex
+++ b/lib/wanderer_app/map/operations/transfer.ex
@@ -1,0 +1,298 @@
+defmodule WandererApp.Map.Operations.Transfer do
+  @moduledoc """
+  Export and import of map contents as a portable document.
+
+  Unlike `WandererApp.Map.Operations.Duplication`, which copies a map inside one instance by
+  writing records directly, transfer produces a plain data structure that can be stored in a file
+  and replayed into any map - including on another deployment. Imports go through the map server
+  so that connected clients see the systems appear as they are added.
+
+  Only map contents are transferred: systems, connections and (optionally) signatures. Access
+  lists, subscriptions and per user settings are deliberately left out - they reference accounts
+  and characters that do not exist on the importing side.
+  """
+
+  require Logger
+
+  alias WandererApp.Api.MapSystemSignature
+  alias WandererApp.Map.Server
+
+  @export_version 1
+
+  @type stats :: %{systems: non_neg_integer(), connections: non_neg_integer(), signatures: non_neg_integer()}
+
+  @doc """
+  Builds the export document for a map.
+
+  Options:
+  - `:include_signatures` - include system signatures (default: true)
+  """
+  @spec export(binary(), keyword()) :: {:ok, map()} | {:error, term()}
+  def export(map_id, opts \\ []) do
+    include_signatures = Keyword.get(opts, :include_signatures, true)
+
+    with {:ok, map} <- WandererApp.MapRepo.get(map_id),
+         {:ok, systems} <- WandererApp.MapSystemRepo.get_visible_by_map(map_id),
+         {:ok, connections} <- WandererApp.MapConnectionRepo.get_by_map(map_id) do
+      {:ok,
+       %{
+         "version" => @export_version,
+         "exported_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+         "map" => %{
+           "name" => map.name,
+           "slug" => map.slug,
+           "description" => map.description
+         },
+         "systems" => Enum.map(systems, &export_system/1),
+         "connections" => Enum.map(connections, &export_connection/1),
+         "signatures" => export_signatures(systems, include_signatures)
+       }}
+    end
+  end
+
+  @doc """
+  Replays an export document into an existing map.
+
+  Systems already present on the target map keep their position and attributes - an import adds
+  what is missing instead of overwriting the map, so it is safe to run against a live chain.
+
+  Options:
+  - `:include_signatures` - import system signatures (default: true)
+  """
+  @spec import(binary(), map(), binary(), binary() | nil, keyword()) ::
+          {:ok, stats()} | {:error, term()}
+  def import(map_id, data, user_id, character_id, opts \\ [])
+
+  def import(map_id, %{"version" => @export_version} = data, user_id, character_id, opts) do
+    include_signatures = Keyword.get(opts, :include_signatures, true)
+
+    systems = Map.get(data, "systems", [])
+    connections = Map.get(data, "connections", [])
+    signatures = if include_signatures, do: Map.get(data, "signatures", []), else: []
+
+    existing_ids = existing_solar_system_ids(map_id)
+
+    imported_systems =
+      systems
+      |> Enum.filter(&is_map/1)
+      |> Enum.map(&import_system(map_id, &1, user_id, character_id, existing_ids))
+      |> Enum.count(& &1)
+
+    imported_connections = import_connections(map_id, connections, user_id, character_id)
+    imported_signatures = import_signatures(map_id, signatures)
+
+    Logger.info(
+      "Imported #{imported_systems} systems, #{imported_connections} connections, " <>
+        "#{imported_signatures} signatures into map #{map_id}"
+    )
+
+    {:ok,
+     %{
+       systems: imported_systems,
+       connections: imported_connections,
+       signatures: imported_signatures
+     }}
+  end
+
+  def import(_map_id, %{"version" => version}, _user_id, _character_id, _opts),
+    do: {:error, {:unsupported_version, version}}
+
+  def import(_map_id, _data, _user_id, _character_id, _opts), do: {:error, :invalid_document}
+
+  # -- export helpers ------------------------------------------------------------------------
+
+  defp export_system(system) do
+    %{
+      "solar_system_id" => system.solar_system_id,
+      "position" => %{"x" => system.position_x, "y" => system.position_y},
+      "name" => system.name,
+      "custom_name" => system.custom_name,
+      "description" => system.description,
+      "labels" => system.labels,
+      "status" => system.status,
+      "tag" => system.tag,
+      "temporary_name" => system.temporary_name,
+      "locked" => system.locked
+    }
+  end
+
+  defp export_connection(connection) do
+    %{
+      "source" => connection.solar_system_source,
+      "target" => connection.solar_system_target,
+      "type" => connection.type,
+      "mass_status" => connection.mass_status,
+      "time_status" => connection.time_status,
+      "ship_size_type" => connection.ship_size_type,
+      "wormhole_type" => connection.wormhole_type,
+      "locked" => connection.locked
+    }
+  end
+
+  defp export_signatures(_systems, false), do: []
+
+  defp export_signatures(systems, true) do
+    Enum.flat_map(systems, fn system ->
+      case MapSystemSignature.by_system_id_all(%{system_id: system.id}) do
+        {:ok, signatures} ->
+          signatures
+          |> Enum.reject(& &1.deleted)
+          |> Enum.map(&export_signature(&1, system.solar_system_id))
+
+        {:error, _} ->
+          []
+      end
+    end)
+  end
+
+  defp export_signature(signature, solar_system_id) do
+    %{
+      "solar_system_id" => solar_system_id,
+      "eve_id" => signature.eve_id,
+      "character_eve_id" => signature.character_eve_id,
+      "name" => signature.name,
+      "temporary_name" => signature.temporary_name,
+      "description" => signature.description,
+      "kind" => signature.kind,
+      "group" => signature.group,
+      "type" => signature.type,
+      "custom_info" => signature.custom_info
+    }
+  end
+
+  # -- import helpers ------------------------------------------------------------------------
+
+  defp existing_solar_system_ids(map_id) do
+    case WandererApp.MapSystemRepo.get_all_by_map(map_id) do
+      {:ok, systems} -> MapSet.new(systems, & &1.solar_system_id)
+      _ -> MapSet.new()
+    end
+  end
+
+  defp import_system(map_id, system, user_id, character_id, existing_ids) do
+    with {:ok, solar_system_id} <- parse_solar_system_id(system["solar_system_id"]),
+         :ok <-
+           Server.add_system(
+             map_id,
+             %{solar_system_id: solar_system_id, coordinates: position(system["position"])},
+             user_id,
+             character_id
+           ) do
+      # a system that was already on the map keeps whatever the map has for it
+      if MapSet.member?(existing_ids, solar_system_id) do
+        false
+      else
+        apply_system_attributes(map_id, solar_system_id, system)
+        true
+      end
+    else
+      error ->
+        Logger.warning("[Transfer] skipped system #{inspect(system)}: #{inspect(error)}")
+        false
+    end
+  end
+
+  @system_attributes [
+    {"custom_name", :custom_name, :update_system_custom_name},
+    {"description", :description, :update_system_description},
+    {"labels", :labels, :update_system_labels},
+    {"status", :status, :update_system_status},
+    {"tag", :tag, :update_system_tag},
+    {"temporary_name", :temporary_name, :update_system_temporary_name},
+    {"locked", :locked, :update_system_locked}
+  ]
+
+  defp apply_system_attributes(map_id, solar_system_id, system) do
+    Enum.each(@system_attributes, fn {key, attribute, fun} ->
+      case Map.get(system, key) do
+        value when value in [nil, "", false] ->
+          :ok
+
+        value ->
+          apply(Server, fun, [map_id, %{:solar_system_id => solar_system_id, attribute => value}])
+      end
+    end)
+  end
+
+  defp import_connections(map_id, connections, user_id, character_id) do
+    paste_payload =
+      connections
+      |> Enum.filter(&is_map/1)
+      |> Enum.flat_map(fn connection ->
+        with {:ok, source} <- parse_solar_system_id(connection["source"]),
+             {:ok, target} <- parse_solar_system_id(connection["target"]) do
+          [
+            connection
+            |> Map.take(["type", "mass_status", "time_status", "ship_size_type", "wormhole_type", "locked"])
+            |> Map.merge(%{"source" => to_string(source), "target" => to_string(target)})
+          ]
+        else
+          _ -> []
+        end
+      end)
+
+    Server.paste_connections(map_id, paste_payload, user_id, character_id)
+
+    length(paste_payload)
+  end
+
+  defp import_signatures(map_id, signatures) do
+    signatures
+    |> Enum.filter(&is_map/1)
+    |> Enum.group_by(& &1["solar_system_id"])
+    |> Enum.reduce(0, fn {solar_system_id, system_signatures}, acc ->
+      with {:ok, parsed_id} <- parse_solar_system_id(solar_system_id),
+           {:ok, system} when not is_nil(system) <-
+             WandererApp.MapSystemRepo.get_by_map_and_solar_system_id(map_id, parsed_id) do
+        acc + create_signatures(system.id, system_signatures)
+      else
+        _ -> acc
+      end
+    end)
+  end
+
+  defp create_signatures(system_id, signatures) do
+    Enum.count(signatures, fn signature ->
+      attrs =
+        signature
+        |> Map.take([
+          "eve_id",
+          "character_eve_id",
+          "name",
+          "temporary_name",
+          "description",
+          "kind",
+          "group",
+          "type",
+          "custom_info"
+        ])
+        |> Map.new(fn {key, value} -> {String.to_existing_atom(key), value} end)
+        |> Map.put(:system_id, system_id)
+
+      case MapSystemSignature.create(attrs) do
+        {:ok, _} ->
+          true
+
+        {:error, reason} ->
+          Logger.warning("[Transfer] skipped signature: #{inspect(reason)}")
+          false
+      end
+    end)
+  end
+
+  defp position(%{"x" => x, "y" => y}) when is_number(x) and is_number(y),
+    do: %{"x" => round(x), "y" => round(y)}
+
+  defp position(_), do: nil
+
+  defp parse_solar_system_id(id) when is_integer(id), do: {:ok, id}
+
+  defp parse_solar_system_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {parsed, ""} -> {:ok, parsed}
+      _ -> {:error, :invalid_solar_system_id}
+    end
+  end
+
+  defp parse_solar_system_id(_), do: {:error, :invalid_solar_system_id}
+end

--- a/lib/wanderer_app_web/controllers/map_api_controller.ex
+++ b/lib/wanderer_app_web/controllers/map_api_controller.ex
@@ -1327,6 +1327,72 @@ defmodule WandererAppWeb.MapAPIController do
     end
   end
 
+  @doc """
+  GET /api/maps/{map_identifier}/export
+
+  Returns the map contents (systems, connections, signatures) as a portable document that can be
+  imported into another map, on this or another instance.
+  """
+  def export_map(%{assigns: %{map_id: map_id}} = conn, params) do
+    include_signatures = params["include_signatures"] not in ["false", false]
+
+    case WandererApp.Map.Operations.Transfer.export(map_id, include_signatures: include_signatures) do
+      {:ok, data} ->
+        json(conn, %{data: data})
+
+      {:error, reason} ->
+        Logger.error("Map export failed: #{inspect(reason)}")
+
+        conn
+        |> put_status(:internal_server_error)
+        |> json(%{error: "Failed to export map"})
+    end
+  end
+
+  @doc """
+  POST /api/maps/{map_identifier}/import
+
+  Replays an exported document into this map. Systems that already exist are left untouched.
+  """
+  def import_map(
+        %{assigns: %{map_id: map_id, owner_character_id: char_id, owner_user_id: user_id}} = conn,
+        params
+      ) do
+    document = params["data"] || params
+
+    include_signatures = params["include_signatures"] not in ["false", false]
+
+    case WandererApp.Map.Operations.Transfer.import(map_id, document, user_id, char_id,
+           include_signatures: include_signatures
+         ) do
+      {:ok, stats} ->
+        json(conn, %{data: stats})
+
+      {:error, {:unsupported_version, version}} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "Unsupported export version: #{version}"})
+
+      {:error, :invalid_document} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "Invalid export document"})
+
+      {:error, reason} ->
+        Logger.error("Map import failed: #{inspect(reason)}")
+
+        conn
+        |> put_status(:internal_server_error)
+        |> json(%{error: "Failed to import map"})
+    end
+  end
+
+  def import_map(conn, _params) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "Map owner character could not be resolved"})
+  end
+
   # Helper functions for map duplication
 
   defp validate_duplicate_params(params) do

--- a/lib/wanderer_app_web/controllers/map_api_controller.ex
+++ b/lib/wanderer_app_web/controllers/map_api_controller.ex
@@ -1336,7 +1336,9 @@ defmodule WandererAppWeb.MapAPIController do
   def export_map(%{assigns: %{map_id: map_id}} = conn, params) do
     include_signatures = params["include_signatures"] not in ["false", false]
 
-    case WandererApp.Map.Operations.Transfer.export(map_id, include_signatures: include_signatures) do
+    case WandererApp.Map.Operations.Transfer.export(map_id,
+           include_signatures: include_signatures
+         ) do
       {:ok, data} ->
         json(conn, %{data: data})
 
@@ -1354,10 +1356,13 @@ defmodule WandererAppWeb.MapAPIController do
 
   Replays an exported document into this map. Systems that already exist are left untouched.
   """
+  # AssignMapOwner assigns both keys even when it cannot resolve an owner, so the guard is what
+  # sends an unresolvable owner to the clause below instead of into an import with a nil user.
   def import_map(
         %{assigns: %{map_id: map_id, owner_character_id: char_id, owner_user_id: user_id}} = conn,
         params
-      ) do
+      )
+      when not is_nil(char_id) and not is_nil(user_id) do
     document = params["data"] || params
 
     include_signatures = params["include_signatures"] not in ["false", false]

--- a/lib/wanderer_app_web/live/map/event_handlers/map_core_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_core_event_handler.ex
@@ -209,10 +209,12 @@ defmodule WandererAppWeb.MapCoreEventHandler do
     {:noreply, socket}
   end
 
+  # Export hands the whole map over as one file, so it asks for the permission to see the map
+  # rather than relying on the caller having got this far.
   def handle_ui_event(
         "export_map_data",
         params,
-        %{assigns: %{map_id: map_id}} = socket
+        %{assigns: %{map_id: map_id, user_permissions: %{view_system: true}}} = socket
       ) do
     include_signatures = Map.get(params || %{}, "include_signatures", true)
 
@@ -264,6 +266,9 @@ defmodule WandererAppWeb.MapCoreEventHandler do
         {:reply, %{error: "Failed to import map data"}, socket}
     end
   end
+
+  def handle_ui_event("export_map_data", _params, socket),
+    do: {:reply, %{error: "You don't have permission to export map data"}, socket}
 
   def handle_ui_event("import_map_data", _params, socket),
     do: {:reply, %{error: "You don't have permission to import map data"}, socket}

--- a/lib/wanderer_app_web/live/map/event_handlers/map_core_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_core_event_handler.ex
@@ -210,6 +210,65 @@ defmodule WandererAppWeb.MapCoreEventHandler do
   end
 
   def handle_ui_event(
+        "export_map_data",
+        params,
+        %{assigns: %{map_id: map_id}} = socket
+      ) do
+    include_signatures = Map.get(params || %{}, "include_signatures", true)
+
+    case WandererApp.Map.Operations.Transfer.export(map_id,
+           include_signatures: include_signatures
+         ) do
+      {:ok, data} ->
+        {:reply, %{data: data}, socket}
+
+      {:error, error} ->
+        Logger.error(fn -> "Failed to export map #{map_id}: #{inspect(error)}" end)
+
+        {:reply, %{error: "Failed to export map data"}, socket}
+    end
+  end
+
+  def handle_ui_event(
+        "import_map_data",
+        %{"data" => data} = params,
+        %{
+          assigns: %{
+            map_id: map_id,
+            current_user: %{id: current_user_id},
+            has_tracked_characters?: true,
+            main_character_id: main_character_id,
+            user_permissions: %{add_system: true}
+          }
+        } = socket
+      )
+      when not is_nil(main_character_id) do
+    include_signatures = Map.get(params, "include_signatures", true)
+
+    case WandererApp.Map.Operations.Transfer.import(
+           map_id,
+           data,
+           current_user_id,
+           main_character_id,
+           include_signatures: include_signatures
+         ) do
+      {:ok, stats} ->
+        {:reply, %{result: stats}, socket}
+
+      {:error, {:unsupported_version, version}} ->
+        {:reply, %{error: "Unsupported export version: #{version}"}, socket}
+
+      {:error, error} ->
+        Logger.error(fn -> "Failed to import map #{map_id}: #{inspect(error)}" end)
+
+        {:reply, %{error: "Failed to import map data"}, socket}
+    end
+  end
+
+  def handle_ui_event("import_map_data", _params, socket),
+    do: {:reply, %{error: "You don't have permission to import map data"}, socket}
+
+  def handle_ui_event(
         "get_user_settings",
         _,
         %{

--- a/lib/wanderer_app_web/router.ex
+++ b/lib/wanderer_app_web/router.ex
@@ -291,6 +291,10 @@ defmodule WandererAppWeb.Router do
     # Map duplication endpoint
     post "/duplicate", MapAPIController, :duplicate_map
 
+    # Map contents export/import
+    get "/export", MapAPIController, :export_map
+    post "/import", MapAPIController, :import_map
+
     patch "/connections", MapConnectionAPIController, :update
     delete "/connections", MapConnectionAPIController, :delete
     delete "/systems", MapSystemAPIController, :delete_batch

--- a/test/integration/map/map_transfer_test.exs
+++ b/test/integration/map/map_transfer_test.exs
@@ -1,0 +1,245 @@
+defmodule WandererApp.Map.MapTransferTest do
+  @moduledoc """
+  The export/import round trip.
+
+  Covers the three things the shape of this feature rests on: what comes out of a map goes back
+  into an empty one, running the same document twice adds nothing the second time, and a system
+  deleted from the target comes back with the attributes the document carries for it.
+  """
+
+  use WandererApp.DataCase
+
+  import WandererApp.MapTestHelpers
+
+  alias WandererApp.Api.MapSystemSignature
+  alias WandererApp.Map.Operations.Transfer
+  alias WandererApp.Map.Server
+
+  @system_a 31_000_101
+  @system_b 31_000_102
+
+  setup do
+    setup_transfer_test_systems()
+    :ok
+  end
+
+  describe "export/2 then import/5" do
+    test "carries systems, their attributes, connections and signatures into an empty map" do
+      source = start_test_map()
+      target = start_test_map()
+
+      seed_source_map(source)
+
+      {:ok, document} = Transfer.export(source.map_id)
+
+      assert document["version"] == 1
+      assert length(document["systems"]) == 2
+      assert length(document["connections"]) == 1
+      assert length(document["signatures"]) == 1
+
+      {:ok, stats} =
+        Transfer.import(target.map_id, document, target.user_id, target.character_id)
+
+      assert stats == %{systems: 2, connections: 1, signatures: 1}
+
+      assert wait_for_system_on_map(target.map_id, @system_a)
+      assert wait_for_system_on_map(target.map_id, @system_b)
+
+      {:ok, system} =
+        WandererApp.MapSystemRepo.get_by_map_and_solar_system_id(target.map_id, @system_a)
+
+      assert system.custom_name == "Home"
+      assert system.description == "staging"
+      assert system.tag == "A"
+      assert system.status == 1
+      assert system.temporary_name == "HS-1"
+      assert system.position_x == 120
+      assert system.position_y == 240
+
+      {:ok, connections} = WandererApp.MapConnectionRepo.get_by_map(target.map_id)
+      assert length(connections) == 1
+
+      {:ok, signatures} = MapSystemSignature.by_system_id(system.id)
+      assert [%{eve_id: "ABC-123", name: "Wormhole"}] = signatures
+
+      cleanup_test_data(source.map_id)
+      cleanup_test_data(target.map_id)
+    end
+
+    test "a second import of the same document adds nothing and says so" do
+      source = start_test_map()
+      target = start_test_map()
+
+      seed_source_map(source)
+
+      {:ok, document} = Transfer.export(source.map_id)
+
+      {:ok, _first} =
+        Transfer.import(target.map_id, document, target.user_id, target.character_id)
+
+      assert wait_for_system_on_map(target.map_id, @system_a)
+
+      {:ok, second} =
+        Transfer.import(target.map_id, document, target.user_id, target.character_id)
+
+      # the counts are the only feedback anyone gets about an import being safe to re-run, so a
+      # no-op has to report zeroes rather than the size of the document
+      assert second == %{systems: 0, connections: 0, signatures: 0}
+
+      cleanup_test_data(source.map_id)
+      cleanup_test_data(target.map_id)
+    end
+
+    test "a system deleted from the target comes back with its attributes" do
+      source = start_test_map()
+      target = start_test_map()
+
+      seed_source_map(source)
+
+      {:ok, document} = Transfer.export(source.map_id)
+      {:ok, _} = Transfer.import(target.map_id, document, target.user_id, target.character_id)
+
+      assert wait_for_system_on_map(target.map_id, @system_a)
+
+      :ok = Server.delete_systems(target.map_id, [@system_a], target.user_id, target.character_id)
+
+      refute system_visible?(target.map_id, @system_a)
+
+      {:ok, stats} =
+        Transfer.import(target.map_id, document, target.user_id, target.character_id)
+
+      # deletion leaves the row behind with visible: false, so counting rows rather than systems
+      # on the map used to treat this one as already present - it came back stripped
+      assert stats.systems == 1
+
+      assert wait_for_system_on_map(target.map_id, @system_a)
+
+      {:ok, system} =
+        WandererApp.MapSystemRepo.get_by_map_and_solar_system_id(target.map_id, @system_a)
+
+      assert system.custom_name == "Home"
+      assert system.tag == "A"
+      assert system.status == 1
+      assert system.temporary_name == "HS-1"
+
+      cleanup_test_data(source.map_id)
+      cleanup_test_data(target.map_id)
+    end
+  end
+
+  describe "import/5 with a document it cannot read" do
+    test "refuses another version and anything that is not a document" do
+      %{map_id: map_id, user_id: user_id, character_id: character_id} = start_test_map()
+
+      assert {:error, {:unsupported_version, 99}} =
+               Transfer.import(map_id, %{"version" => 99}, user_id, character_id)
+
+      assert {:error, :invalid_document} = Transfer.import(map_id, %{}, user_id, character_id)
+
+      cleanup_test_data(map_id)
+    end
+  end
+
+  defp seed_source_map(%{map_id: map_id, user_id: user_id, character_id: character_id}) do
+    :ok =
+      Server.add_system(
+        map_id,
+        %{solar_system_id: @system_a, coordinates: %{"x" => 120, "y" => 240}},
+        user_id,
+        character_id
+      )
+
+    :ok =
+      Server.add_system(
+        map_id,
+        %{solar_system_id: @system_b, coordinates: %{"x" => 300, "y" => 240}},
+        user_id,
+        character_id
+      )
+
+    assert wait_for_system_on_map(map_id, @system_a)
+    assert wait_for_system_on_map(map_id, @system_b)
+
+    Server.update_system_custom_name(map_id, %{solar_system_id: @system_a, custom_name: "Home"})
+
+    Server.update_system_description(map_id, %{solar_system_id: @system_a, description: "staging"})
+
+    Server.update_system_tag(map_id, %{solar_system_id: @system_a, tag: "A"})
+    Server.update_system_status(map_id, %{solar_system_id: @system_a, status: 1})
+
+    Server.update_system_temporary_name(map_id, %{
+      solar_system_id: @system_a,
+      temporary_name: "HS-1"
+    })
+
+    :ok =
+      Server.add_connection(
+        map_id,
+        %{
+          solar_system_source_id: @system_a,
+          solar_system_target_id: @system_b,
+          character_id: character_id
+        }
+      )
+
+    {:ok, system} = WandererApp.MapSystemRepo.get_by_map_and_solar_system_id(map_id, @system_a)
+
+    {:ok, _} =
+      MapSystemSignature.create(%{
+        system_id: system.id,
+        eve_id: "ABC-123",
+        character_eve_id: "90000001",
+        name: "Wormhole",
+        kind: "cosmic_signature",
+        group: "Wormhole"
+      })
+
+    :ok
+  end
+
+  defp system_visible?(map_id, solar_system_id) do
+    case WandererApp.MapSystemRepo.get_visible_by_map(map_id) do
+      {:ok, systems} -> Enum.any?(systems, &(&1.solar_system_id == solar_system_id))
+      _ -> false
+    end
+  end
+
+  defp start_test_map do
+    setup_ddrt_mocks()
+
+    user = insert(:user)
+    character = insert(:character, %{user_id: user.id})
+    map = insert(:map, %{owner_id: character.id})
+
+    :ok = ensure_map_started(map.id)
+
+    %{map_id: map.id, user_id: user.id, character_id: character.id}
+  end
+
+  defp setup_transfer_test_systems do
+    setup_system_static_info_cache(%{
+      @system_a => %{
+        solar_system_id: @system_a,
+        solar_system_name: "J101101",
+        solar_system_name_lc: "j101101",
+        region_id: 11_000_001,
+        constellation_id: 21_000_001,
+        region_name: "A-R00001",
+        constellation_name: "A-C00001",
+        system_class: 1,
+        security: "-1.0"
+      },
+      @system_b => %{
+        solar_system_id: @system_b,
+        solar_system_name: "J101102",
+        solar_system_name_lc: "j101102",
+        region_id: 11_000_001,
+        constellation_id: 21_000_001,
+        region_name: "A-R00001",
+        constellation_name: "A-C00001",
+        system_class: 2,
+        security: "-1.0"
+      }
+    })
+  end
+end


### PR DESCRIPTION
Split out of #632 at @DmitryPopov's request - this is that branch's export/import commit on its own, nothing else changed.

Duplication copies a map inside one instance but has no serialized form, so chains cannot be backed up or moved between deployments.

`WandererApp.Map.Operations.Transfer` produces a versioned document with systems, connections and signatures, and replays it into an existing map through the map server, so connected clients see systems appear as they are added.

- Available from the Import/Export tab of the map user settings, and over the API: `GET /api/maps/{map_identifier}/export`, `POST /api/maps/{map_identifier}/import`.
- Import adds what is missing and leaves systems already on the map untouched, so it is safe to run against a live chain. It is deliberately not a destructive restore.
- Access lists, subscriptions and user settings stay out of the document - they reference accounts and characters that do not exist on the importing side.
- Signature import upserts on `(system_id, eve_id)`, so re-importing does not duplicate signatures.
