### PR TITLE
fix(signatures): lazydelete rows coloring on signatures removal

### DIFF
--- a/lib/wanderer_app_web/live/map/event_handlers/map_signatures_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_signatures_event_handler.ex
@@ -210,7 +210,7 @@ to_remove = removed_signatures |> Enum.filter(fn %{"eve_id" => eve_id} -> "#{sol
 
     {:noreply,
       socket
-        |> assign(removed_sig_eve_ids: updated_removed_sig_eve_ids)} #  NAPRAWIONE: Używamy nowej zmiennej!
+        |> assign(removed_sig_eve_ids: updated_removed_sig_eve_ids)}
   end
 
   def handle_ui_event(

--- a/lib/wanderer_app_web/live/map/event_handlers/map_signatures_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_signatures_event_handler.ex
@@ -110,15 +110,15 @@ to_remove = removed_signatures |> Enum.filter(fn %{"eve_id" => eve_id} -> "#{sol
       removed_signatures: to_remove
     })
 
-socket
-|> assign(
-removed_sig_eve_ids:
-removed_sig_eve_ids
-|> Enum.reject(fn sig_id ->
-sig_id in Enum.map(to_remove_eve_ids, &("#{solar_system_id}_#{&1}")) 
-end)
-)
-end
+    socket
+    |> assign(
+      removed_sig_eve_ids:
+      removed_sig_eve_ids
+    |> Enum.reject(fn sig_id ->
+      sig_id in Enum.map(to_remove_eve_ids, &("#{solar_system_id}_#{&1}")) 
+    end)
+    )
+  end
 
   def handle_server_event(event, socket),
     do: MapCoreEventHandler.handle_server_event(event, socket)
@@ -201,51 +201,50 @@ end
       removed_signatures: []
     })
 
+    saved_eve_ids = (added_signatures ++ updated_signatures) |> Enum.map(fn sig -> sig["eve_id"] end)
+    saved_system_keys = saved_eve_ids |> Enum.map(&("#{solar_system_id}_#{&1}"))
+    just_removed_system_keys = new_removed_sig_eve_ids |> Enum.map(&("#{solar_system_id}_#{&1}"))
+    updated_removed_sig_eve_ids = (old_removed_sig_eve_ids ++ just_removed_system_keys)
+      |> Enum.uniq()
+      |> Enum.reject(fn key -> key in saved_system_keys end)
+
     {:noreply,
-     socket
-     |> assign(
-     removed_sig_eve_ids: (old_removed_sig_eve_ids ++ Enum.map(new_removed_sig_eve_ids, &("#{solar_system_id}_#{&1}"))) |> Enum.uniq()
-     )}
+      socket
+        |> assign(removed_sig_eve_ids: updated_removed_sig_eve_ids)} #  NAPRAWIONE: Używamy nowej zmiennej!
   end
 
-def handle_ui_event(
-"get_signatures",
-%{"system_id" => solar_system_id},
-%{
-assigns:
-%{
-map_id: map_id
-} = assigns
-} = socket
-) do
-solar_system_id_int = get_integer(solar_system_id)
+  def handle_ui_event(
+      "get_signatures",
+        %{"system_id" => solar_system_id},
+          %{
+            assigns:
+          %{
+            map_id: map_id
+          } = assigns
+        } = socket
+      ) do
+        solar_system_id_int = get_integer(solar_system_id)
+        case WandererApp.Api.MapSystem.read_by_map_and_solar_system(%{
+          map_id: map_id,
+          solar_system_id: solar_system_id_int
+        }) do
+          {:ok, system} ->
+            removed_sig_eve_ids = Map.get(assigns, :removed_sig_eve_ids, [])
+            system_signatures =
+              get_system_signatures(system.id)
+                |> Enum.map(fn sig ->
+                  if "#{solar_system_id_int}_#{sig.eve_id}" in removed_sig_eve_ids do
+                    sig |> Map.put(:deleted, true)
+                  else
+                    sig
+                  end
+                end)
 
-case WandererApp.Api.MapSystem.read_by_map_and_solar_system(%{
-map_id: map_id,
-solar_system_id: solar_system_id_int
-}) do
-{:ok, system} ->
-removed_sig_eve_ids = Map.get(assigns, :removed_sig_eve_ids, [])
-
-system_signatures =
-get_system_signatures(system.id)
-|> Enum.map(fn sig ->
-# Posiadamy oryginalny payload w `removed_signatures`, który jest przekazywany w pliku.
-# Zanim nadamy kolor czerwony, upewniamy się, że to ID sygnatury ma prawo świecić w TYM konkretnym systemie.
-# Jeśli w bazie danych ta sygnatura (sig) należy do aktualnego system.id:
-if "#{solar_system_id_int}_#{sig.eve_id}" in removed_sig_eve_ids do
-sig |> Map.put(:deleted, true)
-else
-sig
-end
-end)
-
-{:reply, %{signatures: system_signatures}, socket}
-
-_ ->
-{:reply, %{signatures: []}, socket}
-end
-end
+          {:reply, %{signatures: system_signatures}, socket}
+            _ ->
+            {:reply, %{signatures: []}, socket}
+        end
+  end
 
 
   def handle_ui_event(
@@ -471,15 +470,15 @@ end
       solar_system_id_int = get_integer(solar_system_id)
     WandererApp.Map.Server.Impl.broadcast!(map_id, :signatures_updated, solar_system_id)
 
-{:noreply,
-socket
-|> assign(
-removed_sig_eve_ids:
-removed_sig_eve_ids|> Enum.reject(fn sig_id ->
-sig_id in Enum.map(eve_ids, &("#{solar_system_id_int}_#{&1}"))
-end)
-)}
-end
+    {:noreply,
+      socket
+      |> assign(
+        removed_sig_eve_ids:
+        removed_sig_eve_ids|> Enum.reject(fn sig_id ->
+        sig_id in Enum.map(eve_ids, &("#{solar_system_id_int}_#{&1}"))
+        end)
+      )}
+  end
 
   def handle_ui_event(event, body, socket),
     do: MapCoreEventHandler.handle_ui_event(event, body, socket)

--- a/lib/wanderer_app_web/live/map/event_handlers/map_signatures_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_signatures_event_handler.ex
@@ -93,9 +93,7 @@ defmodule WandererAppWeb.MapSignaturesEventHandler do
       |> WandererApp.MapUserSettingsRepo.to_form_data!()
       |> WandererApp.MapUserSettingsRepo.get_boolean_setting("delete_connection_with_sigs")
 
-    to_remove =
-      removed_signatures
-      |> Enum.filter(fn %{"eve_id" => eve_id} -> eve_id in removed_sig_eve_ids end)
+to_remove = removed_signatures |> Enum.filter(fn %{"eve_id" => eve_id} -> "#{solar_system_id}_#{eve_id}" in removed_sig_eve_ids end)
 
     to_remove_eve_ids =
       to_remove
@@ -112,12 +110,15 @@ defmodule WandererAppWeb.MapSignaturesEventHandler do
       removed_signatures: to_remove
     })
 
-    socket
-    |> assign(
-      removed_sig_eve_ids:
-        removed_sig_eve_ids |> Enum.reject(fn sig_id -> sig_id in to_remove_eve_ids end)
-    )
-  end
+socket
+|> assign(
+removed_sig_eve_ids:
+removed_sig_eve_ids
+|> Enum.reject(fn sig_id ->
+sig_id in Enum.map(to_remove_eve_ids, &("#{solar_system_id}_#{&1}")) 
+end)
+)
+end
 
   def handle_server_event(event, socket),
     do: MapCoreEventHandler.handle_server_event(event, socket)
@@ -203,43 +204,49 @@ defmodule WandererAppWeb.MapSignaturesEventHandler do
     {:noreply,
      socket
      |> assign(
-       removed_sig_eve_ids: (old_removed_sig_eve_ids ++ new_removed_sig_eve_ids) |> Enum.uniq()
+     removed_sig_eve_ids: (old_removed_sig_eve_ids ++ Enum.map(new_removed_sig_eve_ids, &("#{solar_system_id}_#{&1}"))) |> Enum.uniq()
      )}
   end
 
-  def handle_ui_event(
-        "get_signatures",
-        %{"system_id" => solar_system_id},
-        %{
-          assigns:
-            %{
-              map_id: map_id
-            } = assigns
-        } = socket
-      ) do
-    case WandererApp.Api.MapSystem.read_by_map_and_solar_system(%{
-           map_id: map_id,
-           solar_system_id: get_integer(solar_system_id)
-         }) do
-      {:ok, system} ->
-        removed_sig_eve_ids = Map.get(assigns, :removed_sig_eve_ids, [])
+def handle_ui_event(
+"get_signatures",
+%{"system_id" => solar_system_id},
+%{
+assigns:
+%{
+map_id: map_id
+} = assigns
+} = socket
+) do
+solar_system_id_int = get_integer(solar_system_id)
 
-        system_signatures =
-          get_system_signatures(system.id)
-          |> Enum.map(fn sig ->
-            if sig.eve_id in removed_sig_eve_ids do
-              sig |> Map.put(:deleted, true)
-            else
-              sig
-            end
-          end)
+case WandererApp.Api.MapSystem.read_by_map_and_solar_system(%{
+map_id: map_id,
+solar_system_id: solar_system_id_int
+}) do
+{:ok, system} ->
+removed_sig_eve_ids = Map.get(assigns, :removed_sig_eve_ids, [])
 
-        {:reply, %{signatures: system_signatures}, socket}
+system_signatures =
+get_system_signatures(system.id)
+|> Enum.map(fn sig ->
+# Posiadamy oryginalny payload w `removed_signatures`, który jest przekazywany w pliku.
+# Zanim nadamy kolor czerwony, upewniamy się, że to ID sygnatury ma prawo świecić w TYM konkretnym systemie.
+# Jeśli w bazie danych ta sygnatura (sig) należy do aktualnego system.id:
+if "#{solar_system_id_int}_#{sig.eve_id}" in removed_sig_eve_ids do
+sig |> Map.put(:deleted, true)
+else
+sig
+end
+end)
 
-      _ ->
-        {:reply, %{signatures: []}, socket}
-    end
-  end
+{:reply, %{signatures: system_signatures}, socket}
+
+_ ->
+{:reply, %{signatures: []}, socket}
+end
+end
+
 
   def handle_ui_event(
         "link_signature_to_system",
@@ -461,14 +468,18 @@ defmodule WandererAppWeb.MapSignaturesEventHandler do
         } = socket
       )
       when not is_nil(main_character_id) do
+      solar_system_id_int = get_integer(solar_system_id)
     WandererApp.Map.Server.Impl.broadcast!(map_id, :signatures_updated, solar_system_id)
 
-    {:noreply,
-     socket
-     |> assign(
-       removed_sig_eve_ids: removed_sig_eve_ids |> Enum.reject(fn sig_id -> sig_id in eve_ids end)
-     )}
-  end
+{:noreply,
+socket
+|> assign(
+removed_sig_eve_ids:
+removed_sig_eve_ids|> Enum.reject(fn sig_id ->
+sig_id in Enum.map(eve_ids, &("#{solar_system_id_int}_#{&1}"))
+end)
+)}
+end
 
   def handle_ui_event(event, body, socket),
     do: MapCoreEventHandler.handle_ui_event(event, body, socket)


### PR DESCRIPTION
im shure someone noticed it at some point:
<img width="563" height="218" alt="Zrzut ekranu 2026-08-16 153227" src="https://github.com/user-attachments/assets/356b9327-924f-4c2b-a213-9f4d3383de5a" />

bug behavior: when you paste same set of signatures into multiple systems and you proceed to delete them from one, they will be marked for deletion in that system(and removed) but until then they will be colored-red in the other system for how long lazydelete timeout was set.

fix1: decoupled sygnature-ids from between systems
fix2: re-pasting same signatures(or part of them) will stop lazydelete-timer for pending-removal in for those signatures in that system

should not collide with PR #658 
