### PR TITLE
feat(quick menu): dotlan button behavior customization

### DIFF
--- a/assets/js/hooks/Mapper/components/contexts/components/FastSystemActions/FastSystemActions.tsx
+++ b/assets/js/hooks/Mapper/components/contexts/components/FastSystemActions/FastSystemActions.tsx
@@ -2,6 +2,8 @@ import { LayoutEventBlocker, TooltipPosition, WdImageSize, WdImgButton } from '@
 import { ANOIK_ICON, DOTLAN_ICON, ZKB_ICON } from '@/hooks/Mapper/icons';
 import { useCallback, useRef } from 'react';
 
+import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
+
 import clsx from 'clsx';
 import { PrimeIcons } from 'primereact/api';
 import classes from './FastSystemActions.module.scss';
@@ -23,8 +25,14 @@ export const FastSystemActions = ({
   onOpenSettings,
   showEdit,
 }: FastSystemActionsProps) => {
-  const ref = useRef({ systemId, systemName, regionName, isWH });
-  ref.current = { systemId, systemName, regionName, isWH };
+  const {
+    storedSettings: { interfaceSettings },
+  } = useMapRootState();
+
+  const dotlanBehavior = interfaceSettings?.dotlan_behavior || 'system';
+
+  const ref = useRef({ systemId, systemName, regionName, isWH, dotlanBehavior });
+  ref.current = { systemId, systemName, regionName, isWH, dotlanBehavior };
 
   const handleOpenZKB = useCallback(
     () => window.open(`https://zkillboard.com/system/${ref.current.systemId}/`, '_blank'),
@@ -32,20 +40,25 @@ export const FastSystemActions = ({
   );
 
   const handleOpenAnoikis = useCallback(
-    () => window.open(`http://anoik.is/systems/${ref.current.systemName}`, '_blank'),
+    () => window.open(`https://anoik.is/systems/${ref.current.systemName}`, '_blank'),
     [],
   );
 
   const handleOpenDotlan = useCallback(() => {
-    if (ref.current.isWH) {
-      window.open(`https://evemaps.dotlan.net/system/${ref.current.systemName}`, '_blank');
+    const { isWH, systemName, regionName, dotlanBehavior } = ref.current;
+
+    if (isWH) {
+      window.open(`https://evemaps.dotlan.net/system/${systemName}`, '_blank');
       return;
     }
 
-    return window.open(
-      `https://evemaps.dotlan.net/map/${ref.current.regionName.replace(/ /gim, '_')}/${ref.current.systemName}#jumps`,
-      '_blank',
-    );
+    const formattedRegion = regionName.replace(/ /gim, '_');
+    if (dotlanBehavior === 'system') {
+      window.open(`https://evemaps.dotlan.net/system/${systemName}`, '_blank');
+      return;
+    }
+
+    window.open(`https://evemaps.dotlan.net/map/${formattedRegion}/${systemName}#${dotlanBehavior}`, '_blank');
   }, []);
 
   const copySystemNameToClipboard = useCallback(async () => {

--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemInfo/SystemInfo.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemInfo/SystemInfo.tsx
@@ -89,7 +89,7 @@ export const SystemInfo = () => {
                 <img src={ANOIK_ICON} alt="Anoikis" width="14" height="14" className="external-icon" />
               </button>
               <button type="button" onClick={handleOpenDotlan} className="cursor-pointer">
-                <img src={DOTLAN_ICON} alt="Dotlan" alt="" width="14" height="14" className="external-icon" />
+                <img src={DOTLAN_ICON} alt="Dotlan" width="14" height="14" className="external-icon" />
               </button>
             </LayoutEventBlocker>
           </div>

--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemInfo/SystemInfo.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemInfo/SystemInfo.tsx
@@ -4,6 +4,7 @@ import { LayoutEventBlocker, SystemView, TooltipPosition, WdImgButton } from '@/
 import { ANOIK_ICON, DOTLAN_ICON, ZKB_ICON } from '@/hooks/Mapper/icons';
 import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
 import { getSystemStaticInfo } from '@/hooks/Mapper/mapRootProvider/hooks/useLoadSystemStatic';
+import { isWormholeSpace } from '@/hooks/Mapper/components/map/helpers/isWormholeSpace.ts';
 import { PrimeIcons } from 'primereact/api';
 import { useCallback, useState } from 'react';
 import { SystemInfoContent } from './SystemInfoContent';
@@ -13,12 +14,17 @@ export const SystemInfo = () => {
 
   const {
     data: { selectedSystems },
+    storedSettings: { interfaceSettings },
   } = useMapRootState();
 
   const [systemId] = selectedSystems;
 
   const systemStaticInfo = getSystemStaticInfo(systemId)!;
-  const { solar_system_name: solarSystemName } = systemStaticInfo || {};
+  const {
+    solar_system_name: solarSystemName,
+    region_name: regionName,
+    system_class: systemClass,
+  } = systemStaticInfo || {};
 
   const isNotSelectedSystem = selectedSystems.length !== 1;
 
@@ -29,6 +35,34 @@ export const SystemInfo = () => {
       console.error(err);
     }
   }, [solarSystemName]);
+
+  const handleOpenZKB = useCallback(() => {
+    if (!systemId) return;
+    window.open(`https://zkillboard.com/system/${systemId}/`, '_blank');
+  }, [systemId]);
+
+  const handleOpenAnoikis = useCallback(() => {
+    if (!solarSystemName) return;
+    window.open(`https://anoik.is/systems/${solarSystemName}`, '_blank');
+  }, [solarSystemName]);
+
+  const handleOpenDotlan = useCallback(() => {
+    if (!solarSystemName || !regionName) return;
+
+    const isWH = isWormholeSpace(systemClass);
+    const dotlanBehavior = interfaceSettings?.dotlan_behavior || 'system';
+    if (isWH) {
+      window.open(`https://evemaps.dotlan.net/system/${solarSystemName}`, '_blank');
+      return;
+    }
+
+    const formattedRegion = regionName.replace(/ /gim, '_');
+    if (dotlanBehavior === 'system') {
+      window.open(`https://evemaps.dotlan.net/system/${solarSystemName}`, '_blank');
+      return;
+    }
+    window.open(`https://evemaps.dotlan.net/map/${formattedRegion}/${solarSystemName}#${dotlanBehavior}`, '_blank');
+  }, [solarSystemName, regionName, systemClass, interfaceSettings]);
 
   return (
     <Widget
@@ -48,15 +82,15 @@ export const SystemInfo = () => {
             </div>
 
             <LayoutEventBlocker className="flex gap-1 items-center">
-              <a href={`https://zkillboard.com/system/${systemId}/`} rel="noreferrer" target="_blank">
-                <img src={ZKB_ICON} width="14" height="14" className="external-icon" />
-              </a>
-              <a href={`http://anoik.is/systems/${solarSystemName}`} rel="noreferrer" target="_blank">
-                <img src={ANOIK_ICON} width="14" height="14" className="external-icon" />
-              </a>
-              <a href={`https://evemaps.dotlan.net/system/${solarSystemName}`} rel="noreferrer" target="_blank">
-                <img src={DOTLAN_ICON} alt="" width="14" height="14" className="external-icon" />
-              </a>
+              <button type="button" onClick={handleOpenZKB} className="cursor-pointer">
+                <img src={ZKB_ICON} alt="zKillboard" width="14" height="14" className="external-icon" />
+              </button>
+              <button type="button" onClick={handleOpenAnoikis} className="cursor-pointer">
+                <img src={ANOIK_ICON} alt="Anoikis" width="14" height="14" className="external-icon" />
+              </button>
+              <button type="button" onClick={handleOpenDotlan} className="cursor-pointer">
+                <img src={DOTLAN_ICON} alt="Dotlan" alt="" width="14" height="14" className="external-icon" />
+              </button>
             </LayoutEventBlocker>
           </div>
         )

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/MapSettings.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/MapSettings.tsx
@@ -4,7 +4,12 @@ import { useCallback, useRef, useState } from 'react';
 import { TabPanel, TabView } from 'primereact/tabview';
 import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
 import { OutCommand, UserPermission } from '@/hooks/Mapper/types';
-import { CONNECTIONS_CHECKBOXES_PROPS, SIGNATURES_CHECKBOXES_PROPS, SYSTEMS_CHECKBOXES_PROPS } from './constants.ts';
+import {
+  CONNECTIONS_CHECKBOXES_PROPS,
+  DOTLAN_DEFAULTBEHAVIOR_PROPS,
+  SIGNATURES_CHECKBOXES_PROPS,
+  SYSTEMS_CHECKBOXES_PROPS,
+} from './constants.ts';
 import {
   MapSettingsProvider,
   useMapSettings,
@@ -80,7 +85,12 @@ export const MapSettingsComp = ({ visible, onHide }: MapSettingsProps) => {
             </TabPanel>
 
             <TabPanel header="Systems" headerClassName={styles.verticalTabHeader}>
-              <div className="w-full h-full flex flex-col gap-1">{renderSettingsList(SYSTEMS_CHECKBOXES_PROPS)}</div>
+              <div className="w-full h-full flex flex-col gap-1">
+                {renderSettingsList(SYSTEMS_CHECKBOXES_PROPS)}
+                <div className="mt-3 pt-3 border-t border-stone-800">
+                  {renderSettingItem(DOTLAN_DEFAULTBEHAVIOR_PROPS)}
+                </div>
+              </div>
             </TabPanel>
 
             <TabPanel header="Connections" headerClassName={styles.verticalTabHeader}>

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/MapSettings.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/MapSettings.tsx
@@ -1,9 +1,9 @@
 import styles from './MapSettings.module.scss';
 import { Dialog } from 'primereact/dialog';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { TabPanel, TabView } from 'primereact/tabview';
-import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
-import { OutCommand, UserPermission } from '@/hooks/Mapper/types';
+
+import { UserPermission } from '@/hooks/Mapper/types';
 import {
   CONNECTIONS_CHECKBOXES_PROPS,
   DOTLAN_DEFAULTBEHAVIOR_PROPS,
@@ -30,34 +30,14 @@ export interface MapSettingsProps {
 
 export const MapSettingsComp = ({ visible, onHide }: MapSettingsProps) => {
   const [activeIndex, setActiveIndex] = useState(0);
-  const { outCommand } = useMapRootState();
-
-  const { renderSettingItem, setUserRemoteSettings, settings } = useMapSettings();
+  const { renderSettingItem } = useMapSettings();
   const isAdmin = useMapCheckPermissions([UserPermission.ADMIN_MAP]);
 
-  const refVars = useRef({ outCommand, onHide, visible });
-  refVars.current = { outCommand, onHide, visible };
-
-  const handleShow = useCallback(async () => {
-    // TODO: need fix it - add type?
-    // @ts-ignore
-    const { user_settings } = await refVars.current.outCommand({
-      type: OutCommand.getUserSettings,
-      data: null,
-    });
-    setUserRemoteSettings({
-      ...user_settings,
-    });
-  }, [setUserRemoteSettings]);
-
   const handleHide = useCallback(() => {
-    if (!refVars.current.visible) {
-      return;
-    }
-
+    if (!visible) return;
     setActiveIndex(0);
-    refVars.current.onHide();
-  }, []);
+    onHide();
+  }, [visible, onHide]);
 
   const renderSettingsList = (list: SettingsListItem[]) => {
     return list.map(renderSettingItem);
@@ -66,11 +46,10 @@ export const MapSettingsComp = ({ visible, onHide }: MapSettingsProps) => {
   return (
     <Dialog
       header="Map user settings"
-      visible
+      visible={visible}
       draggable={false}
       className="w-[600px] h-[460px]"
       contentClassName="custom-scrollbar"
-      onShow={handleShow}
       onHide={handleHide}
     >
       <div className="flex flex-col gap-3 h-full">

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/MapSettingsProvider.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/MapSettingsProvider.tsx
@@ -81,13 +81,13 @@ export const MapSettingsProvider = ({ children }: WithChildren) => {
   const renderSettingItem = useCallback(
     (item: SettingsListItem) => {
       if (item.dependsOn) {
-        const dependsOnValue = refVars.current.mergedSettings[item.dependsOn];
+        const dependsOnValue = mergedSettings[item.dependsOn];
         if (!dependsOnValue) {
           return null;
         }
       }
 
-      const currentValue = refVars.current.mergedSettings[item.prop];
+      const currentValue = mergedSettings[item.prop];
 
       if (item.type === 'checkbox') {
         return (
@@ -110,7 +110,9 @@ export const MapSettingsProvider = ({ children }: WithChildren) => {
               value={currentValue}
               options={item.options}
               onChange={e => handleSettingChange(item.prop, e.value)}
-              placeholder="Select a theme"
+              optionLabel="label"
+              optionValue="value"
+              placeholder={item.placeholder || 'Select Theme'}
             />
           </div>
         );
@@ -133,7 +135,7 @@ export const MapSettingsProvider = ({ children }: WithChildren) => {
 
       return null;
     },
-    [handleSettingChange],
+    [handleSettingChange, mergedSettings],
   );
 
   return (

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/constants.ts
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/constants.ts
@@ -15,6 +15,7 @@ export const DEFAULT_REMOTE_SETTINGS = {
   [UserSettingsRemoteProps.system_custom_label_name]: '',
   [UserSettingsRemoteProps.bookmark_return_hole_ignore]: false,
   [UserSettingsRemoteProps.bookmark_return_hole_symbol]: '',
+  [UserSettingsRemoteProps.dotlan_behavior]: 'system',
 };
 
 export const AUTO_FORMAT_OPTIONS = [
@@ -38,7 +39,37 @@ export const UserSettingsRemoteList = [
   UserSettingsRemoteProps.system_custom_label_name,
   UserSettingsRemoteProps.bookmark_return_hole_ignore,
   UserSettingsRemoteProps.bookmark_return_hole_symbol,
+  UserSettingsRemoteProps.dotlan_behavior,
 ];
+
+export const DOTLAN_BEHAVIOR_VALUES = {
+  DEFAULT: 'system',
+  MAP_SECURITY: 'sec',
+  MAP_SOVEREIGNTY: 'sov',
+  MAP_CONSTELLATION: 'constellation',
+  MAP_JUMPS: 'jumps',
+  MAP_PVP_KILLS: 'kills',
+  MAP_NPC_KILLS: 'npc',
+  MAP_NPC_KILLS_DELTA: 'npcdelta',
+};
+
+export const DOTLAN_BEHAVIOR_OPTIONS = [
+  { label: 'System info', value: DOTLAN_BEHAVIOR_VALUES.DEFAULT },
+  { label: '(map) Security lvl', value: DOTLAN_BEHAVIOR_VALUES.MAP_SECURITY },
+  { label: '(map) Sovereignty', value: DOTLAN_BEHAVIOR_VALUES.MAP_SOVEREIGNTY },
+  { label: '(map) Constellation', value: DOTLAN_BEHAVIOR_VALUES.MAP_CONSTELLATION },
+  { label: '(map) Gate Jumps', value: DOTLAN_BEHAVIOR_VALUES.MAP_JUMPS },
+  { label: '(map) PvP Kills', value: DOTLAN_BEHAVIOR_VALUES.MAP_PVP_KILLS },
+  { label: '(map) NPC Kills', value: DOTLAN_BEHAVIOR_VALUES.MAP_NPC_KILLS },
+  { label: '(map) NPC Kills-delta', value: DOTLAN_BEHAVIOR_VALUES.MAP_NPC_KILLS_DELTA },
+];
+
+export const DOTLAN_DEFAULTBEHAVIOR_PROPS: SettingsListItem = {
+  prop: UserSettingsRemoteProps.dotlan_behavior,
+  label: 'Dotlan Opens',
+  type: 'dropdown',
+  options: DOTLAN_BEHAVIOR_OPTIONS,
+};
 
 // export const COMMON_CHECKBOXES_PROPS: SettingsListItem[] = [
 //   // {

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/constants.ts
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/constants.ts
@@ -39,37 +39,32 @@ export const UserSettingsRemoteList = [
   UserSettingsRemoteProps.system_custom_label_name,
   UserSettingsRemoteProps.bookmark_return_hole_ignore,
   UserSettingsRemoteProps.bookmark_return_hole_symbol,
-  UserSettingsRemoteProps.dotlan_behavior,
-];
-
-export const DOTLAN_BEHAVIOR_VALUES = {
-  DEFAULT: 'system',
-  MAP_SECURITY: 'sec',
-  MAP_SOVEREIGNTY: 'sov',
-  MAP_CONSTELLATION: 'constellation',
-  MAP_JUMPS: 'jumps',
-  MAP_PVP_KILLS: 'kills',
-  MAP_NPC_KILLS: 'npc',
-  MAP_NPC_KILLS_DELTA: 'npcdelta',
-};
-
-export const DOTLAN_BEHAVIOR_OPTIONS = [
-  { label: 'System info', value: DOTLAN_BEHAVIOR_VALUES.DEFAULT },
-  { label: '(map) Security lvl', value: DOTLAN_BEHAVIOR_VALUES.MAP_SECURITY },
-  { label: '(map) Sovereignty', value: DOTLAN_BEHAVIOR_VALUES.MAP_SOVEREIGNTY },
-  { label: '(map) Constellation', value: DOTLAN_BEHAVIOR_VALUES.MAP_CONSTELLATION },
-  { label: '(map) Gate Jumps', value: DOTLAN_BEHAVIOR_VALUES.MAP_JUMPS },
-  { label: '(map) PvP Kills', value: DOTLAN_BEHAVIOR_VALUES.MAP_PVP_KILLS },
-  { label: '(map) NPC Kills', value: DOTLAN_BEHAVIOR_VALUES.MAP_NPC_KILLS },
-  { label: '(map) NPC Kills-delta', value: DOTLAN_BEHAVIOR_VALUES.MAP_NPC_KILLS_DELTA },
 ];
 
 export const DOTLAN_DEFAULTBEHAVIOR_PROPS: SettingsListItem = {
   prop: UserSettingsRemoteProps.dotlan_behavior,
-  label: 'Dotlan Opens',
+  label: 'Dotlan Shortcut Opens',
   type: 'dropdown',
-  options: DOTLAN_BEHAVIOR_OPTIONS,
+  options: [
+    { label: 'System info', value: 'system' },
+    { label: '(map) Security lvl', value: 'sec' },
+    { label: '(map) Sovereignty', value: 'sov' },
+    { label: '(map) Constellation', value: 'const' },
+    { label: '(map) Gate Jumps', value: 'jumps' },
+    { label: '(map) PvP Kills', value: 'kills' },
+    { label: '(map) NPC Kills', value: 'npc' },
+    { label: '(map) NPC Kills-delta', value: 'npc_delta' },
+  ],
+  placeholder: 'System info (default)',
 };
+
+export const DOTLAN_BEHAVIOR_VALUES = DOTLAN_DEFAULTBEHAVIOR_PROPS.options!.reduce(
+  (acc, opt) => {
+    acc[opt.value] = opt.value;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
 
 // export const COMMON_CHECKBOXES_PROPS: SettingsListItem[] = [
 //   // {

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/types.ts
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/types.ts
@@ -13,6 +13,7 @@ export enum UserSettingsRemoteProps {
   system_custom_label_name = 'system_custom_label_name',
   bookmark_return_hole_ignore = 'bookmark_return_hole_ignore',
   bookmark_return_hole_symbol = 'bookmark_return_hole_symbol',
+  dotlan_behavior = 'dotlan_behavior',
 }
 
 export type UserSettingsRemote = {
@@ -28,6 +29,7 @@ export type UserSettingsRemote = {
   system_custom_label_name: string;
   bookmark_return_hole_ignore: boolean;
   bookmark_return_hole_symbol: string;
+  dotlan_behavior: string;
 };
 
 export type UserSettings = UserSettingsRemote & InterfaceStoredSettings;

--- a/assets/js/hooks/Mapper/mapRootProvider/constants.ts
+++ b/assets/js/hooks/Mapper/mapRootProvider/constants.ts
@@ -23,6 +23,7 @@ export const STORED_INTERFACE_DEFAULT_VALUES: InterfaceStoredSettings = {
   pingsPlacement: PingsPlacement.rightTop,
   minimapPlacement: MiniMapPlacement.rightBottom,
   hideBookmarkWarning: false,
+  dotlan_behavior: 'system',
 };
 
 export const DEFAULT_ROUTES_SETTINGS: RoutesType = {

--- a/assets/js/hooks/Mapper/mapRootProvider/types.ts
+++ b/assets/js/hooks/Mapper/mapRootProvider/types.ts
@@ -35,6 +35,7 @@ export type InterfaceStoredSettings = {
   minimapPlacement: MiniMapPlacement;
   pingsPlacement: PingsPlacement;
   hideBookmarkWarning: boolean;
+  dotlan_behavior: string;
 };
 
 export type RoutesType = {


### PR DESCRIPTION
it was bugging me for some time that clicking "go to dotlan" action button was landing me on /system instead of the map.
i gues there is a lot of stuff it shows, but for me i preffer to land on region map with #sec-status.... and someone else may want to see kills or jumps. i know you can click through but what if you could pick default page to open ?

now you can set it in the menu :P

<img width="287" height="319" alt="Zrzut ekranu 2026-09-06 181220" src="https://github.com/user-attachments/assets/ff803025-1626-4508-a0e4-40b01c86baec" />
<img width="584" height="423" alt="Zrzut ekranu 2026-09-06 180951" src="https://github.com/user-attachments/assets/13e25d46-09c2-4c76-9fc3-a022f0fd7a1c" />

possible issue: 
1. migratioin thingy with "undefined" (to_5.ts - you know)
2.  after cleanup i cut out part of code that looked like it didnt do much anymore, but need someone to double check since it had comment "// TODO: need fix it - add type?" on it (file MapSettings.tsx)