### PR TITLE
fix: make map webhooks usable

### DIFF
--- a/lib/wanderer_app/api/map_webhook_subscription.ex
+++ b/lib/wanderer_app/api/map_webhook_subscription.ex
@@ -138,7 +138,7 @@ defmodule WandererApp.Api.MapWebhookSubscription do
       # Generate secret on creation
       change fn changeset, _context ->
         secret = generate_webhook_secret()
-        Ash.Changeset.force_change_attribute(changeset, :secret, secret)
+        AshCloak.encrypt_and_set(changeset, :secret, secret)
       end
 
       # Invalidate cache when subscription is created
@@ -154,7 +154,7 @@ defmodule WandererApp.Api.MapWebhookSubscription do
 
       change fn changeset, _context ->
         new_secret = generate_webhook_secret()
-        Ash.Changeset.change_attribute(changeset, :secret, new_secret)
+        AshCloak.encrypt_and_set(changeset, :secret, new_secret)
       end
 
       change after_action(fn _changeset, record, _context ->

--- a/lib/wanderer_app_web/controllers/map_api_controller.ex
+++ b/lib/wanderer_app_web/controllers/map_api_controller.ex
@@ -1071,7 +1071,7 @@ defmodule WandererAppWeb.MapAPIController do
   operation(:toggle_webhooks,
     summary: "Toggle webhooks for a map",
     parameters: [
-      map_id: [
+      map_identifier: [
         in: :path,
         schema: %OpenApiSpex.Schema{type: :string},
         required: true,
@@ -1106,7 +1106,7 @@ defmodule WandererAppWeb.MapAPIController do
     }
   )
 
-  def toggle_webhooks(conn, %{"map_id" => map_identifier, "enabled" => enabled}) do
+  def toggle_webhooks(conn, %{"map_identifier" => map_identifier, "enabled" => enabled}) do
     with {:ok, enabled_boolean} <- validate_boolean_param(enabled, "enabled"),
          :ok <- check_global_webhooks_enabled(),
          {:ok, map} <- resolve_map_identifier(map_identifier),
@@ -1140,6 +1140,13 @@ defmodule WandererAppWeb.MapAPIController do
         |> put_status(:bad_request)
         |> json(%{error: "Failed to update webhook settings: #{APIUtils.format_error(reason)}"})
     end
+  end
+
+  def toggle_webhooks(conn, %{"map_id" => map_identifier} = params) do
+    toggle_webhooks(
+      conn,
+      params |> Map.delete("map_id") |> Map.put("map_identifier", map_identifier)
+    )
   end
 
   # Helper functions for webhook toggle

--- a/lib/wanderer_app_web/router.ex
+++ b/lib/wanderer_app_web/router.ex
@@ -315,13 +315,13 @@ defmodule WandererAppWeb.Router do
 
     get "/events", MapEventsAPIController, :list_events
 
+    # This static route must precede the resource routes so "toggle" is not parsed as :id.
+    put "/webhooks/toggle", MapAPIController, :toggle_webhooks
+
     # Webhook management endpoints
     resources "/webhooks", MapWebhooksAPIController, except: [:new, :edit] do
       post "/rotate-secret", MapWebhooksAPIController, :rotate_secret
     end
-
-    # Webhook control endpoint
-    put "/webhooks/toggle", MapAPIController, :toggle_webhooks
   end
 
   #

--- a/test/unit/map_webhook_subscription_test.exs
+++ b/test/unit/map_webhook_subscription_test.exs
@@ -1,0 +1,44 @@
+defmodule WandererApp.Api.MapWebhookSubscriptionTest do
+  use WandererApp.DataCase, async: false
+
+  alias WandererApp.Api.MapWebhookSubscription
+
+  describe "secret lifecycle" do
+    test "generates an encrypted secret when creating a subscription" do
+      map = insert(:map)
+
+      assert {:ok, webhook} =
+               MapWebhookSubscription.create(%{
+                 map_id: map.id,
+                 url: "https://example.com/webhook",
+                 events: ["add_system"],
+                 active?: true
+               })
+
+      assert is_binary(webhook.secret)
+      assert byte_size(webhook.secret) > 0
+      assert is_binary(webhook.encrypted_secret)
+      refute webhook.encrypted_secret == webhook.secret
+    end
+
+    test "replaces and encrypts the secret when rotating it" do
+      map = insert(:map)
+
+      assert {:ok, webhook} =
+               MapWebhookSubscription.create(%{
+                 map_id: map.id,
+                 url: "https://example.com/webhook",
+                 events: ["add_system"],
+                 active?: true
+               })
+
+      assert {:ok, rotated_webhook} = MapWebhookSubscription.rotate_secret(webhook)
+
+      refute rotated_webhook.secret == webhook.secret
+      refute rotated_webhook.encrypted_secret == webhook.encrypted_secret
+      assert is_binary(rotated_webhook.secret)
+      assert is_binary(rotated_webhook.encrypted_secret)
+      refute rotated_webhook.encrypted_secret == rotated_webhook.secret
+    end
+  end
+end

--- a/test/unit/webhook_routes_test.exs
+++ b/test/unit/webhook_routes_test.exs
@@ -1,0 +1,73 @@
+defmodule WandererAppWeb.WebhookRoutesTest do
+  use WandererAppWeb.ConnCase, async: false
+
+  alias WandererAppWeb.MapAPIController
+
+  import WandererAppWeb.Factory
+
+  test "routes webhook toggle requests to the map controller" do
+    route =
+      Phoenix.Router.route_info(
+        WandererAppWeb.Router,
+        "PUT",
+        "/api/maps/example-map/webhooks/toggle",
+        "localhost"
+      )
+
+    assert %{
+             plug: WandererAppWeb.MapAPIController,
+             plug_opts: :toggle_webhooks,
+             path_params: %{"map_identifier" => "example-map"}
+           } = route
+  end
+
+  test "toggles webhooks using the route's map identifier parameter" do
+    enable_webhooks()
+
+    map = insert(:map)
+    conn = build_conn() |> assign(:current_character, %{id: map.owner_id})
+
+    response =
+      MapAPIController.toggle_webhooks(conn, %{
+        "map_identifier" => map.slug,
+        "enabled" => true
+      })
+
+    assert %{"webhooks_enabled" => true} = json_response(response, 200)
+  end
+
+  test "does not let a body map_id override the authenticated path map" do
+    enable_webhooks()
+
+    path_map = insert(:map)
+    other_map = insert(:map, %{owner_id: path_map.owner_id})
+
+    response =
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{path_map.public_api_key}")
+      |> put("/api/maps/#{path_map.slug}/webhooks/toggle", %{
+        "enabled" => true,
+        "map_id" => other_map.id
+      })
+
+    assert %{"webhooks_enabled" => true} = json_response(response, 200)
+    assert {:ok, updated_path_map} = WandererApp.Api.Map.by_id(path_map.id)
+    assert {:ok, unchanged_other_map} = WandererApp.Api.Map.by_id(other_map.id)
+    assert updated_path_map.webhooks_enabled
+    refute unchanged_other_map.webhooks_enabled
+  end
+
+  defp enable_webhooks do
+    external_events = Application.get_env(:wanderer_app, :external_events, [])
+
+    Application.put_env(
+      :wanderer_app,
+      :external_events,
+      Keyword.put(external_events, :webhooks_enabled, true)
+    )
+
+    on_exit(fn ->
+      Application.put_env(:wanderer_app, :external_events, external_events)
+    end)
+  end
+end


### PR DESCRIPTION
Enabling webhooks returned “Webhook not found,” and creating a webhook failed with “Invalid attribute: secret.” Webhook toggling, creation, and secret rotation now work correctly.

@DmitryPopov @DanSylvest